### PR TITLE
Add torrent pause toggle flow

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -28,6 +28,7 @@
         "@radix-ui/react-separator": "^1.1.7",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-tabs": "^1.1.13",
+        "@radix-ui/react-tooltip": "^1.2.8",
         "@tailwindcss/vite": "^4.1.13",
         "@tanstack/react-query": "^5.83.0",
         "@tanstack/react-query-devtools": "^5.83.0",

--- a/client/package.json
+++ b/client/package.json
@@ -21,6 +21,7 @@
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tabs": "^1.1.13",
+    "@radix-ui/react-tooltip": "^1.2.8",
     "@tailwindcss/vite": "^4.1.13",
     "@tanstack/react-query": "^5.83.0",
     "@tanstack/react-query-devtools": "^5.83.0",

--- a/client/src/components/EditTorrentDialog/ConfirmDelete.tsx
+++ b/client/src/components/EditTorrentDialog/ConfirmDelete.tsx
@@ -16,7 +16,7 @@ export default function ConfirmDelete({
 }) {
   return (
     <Popover>
-      <PopoverTrigger className='flex mr-auto' asChild>
+      <PopoverTrigger className='flex' asChild>
         {children}
       </PopoverTrigger>
       <PopoverContent className='w-72 bg-card mt-2' side='bottom'>

--- a/client/src/components/EditTorrentDialog/index.tsx
+++ b/client/src/components/EditTorrentDialog/index.tsx
@@ -81,7 +81,7 @@ export default function EditTorrentDialog({
 
   const handleSave = async (id: number, episodes: number[]) => {
     const resp = await (
-      await rpc.api.torrents[':id'].save.$post({
+      await rpc.api.torrents[':id']['save-tracked-ep'].$post({
         json: { episodes },
         param: { id: String(id) },
       })

--- a/client/src/components/EditTorrentDialog/index.tsx
+++ b/client/src/components/EditTorrentDialog/index.tsx
@@ -9,7 +9,7 @@ import {
 } from '@/components/ui/dialog';
 import { useEffect, useState } from 'react';
 import EpPicker from './EpPicker';
-import { Loader2, Trash2 } from 'lucide-react';
+import { Loader2, Pause, Play, Trash2 } from 'lucide-react';
 import DataTabs from './Tabs';
 import FileList from './FileList';
 import ConfirmDelete from './ConfirmDelete';
@@ -184,6 +184,34 @@ export default function EditTorrentDialog({
     }
   };
 
+  const handlePauseToggle = async () => {
+    if (!data) return;
+    try {
+      const resp = await (
+        await rpc.api.torrents[':id']['pause-toggle'].$put({
+          param: { id: String(data?.id) },
+        })
+      ).json();
+      if (!resp.success) {
+        customSonner({
+          variant: 'error',
+          text: resp.message || 'Failed to pause/unpause torrent',
+        });
+        return;
+      }
+      customSonner({
+        text: resp.message || 'Paused/unpaused torrent successfully!',
+      });
+    } catch (error) {
+      customSonner({
+        variant: 'error',
+        text: 'Failed to pause/unpause torrent: ' + error,
+      });
+    } finally {
+      setStartFetch(Date.now());
+    }
+  };
+
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent
@@ -203,6 +231,7 @@ export default function EditTorrentDialog({
               handleDelete={handleDelete}
               handleAddToClient={handleAddToClient}
               handleRmFromClient={handleRmFromClient}
+              handlePauseToggle={handlePauseToggle}
               isAddingToClient={isAddingToClient}
               isRemovingFromClient={isRemovingFromClient}
             />
@@ -283,6 +312,7 @@ function DialogFooterContent({
   handleRmFromClient,
   isAddingToClient,
   isRemovingFromClient,
+  handlePauseToggle,
 }: {
   data: TorrentItemDto;
   handleDelete: (withFiles: boolean) => Promise<void>;
@@ -290,6 +320,7 @@ function DialogFooterContent({
   handleRmFromClient: () => Promise<void>;
   isAddingToClient: boolean;
   isRemovingFromClient: boolean;
+  handlePauseToggle: () => Promise<void>;
 }) {
   return (
     <DialogFooter className='flex flex-row items-center relative border-t border-border px-6 h-20'>
@@ -300,9 +331,24 @@ function DialogFooterContent({
           type='button'
           variant='destructive'
           className='font-extrabold h-10 hover:transform-none'>
-          Delete
+          <Trash2 className='w-4 h-4' />
         </Button>
       </ConfirmDelete>
+      <Button
+        type='button'
+        variant='outline'
+        disabled={
+          data.controlStatus !== 'idle' && data.controlStatus !== 'paused'
+        }
+        onClick={handlePauseToggle}
+        className='font-extrabold h-10 hover:transform-none mr-auto'>
+        {data.controlStatus === 'paused' ? (
+          <Play className='w-4 h-4' />
+        ) : (
+          <Pause className='w-4 h-4' />
+        )}
+      </Button>
+
       {data.controlStatus === 'idle' && (
         <Button
           type='button'
@@ -320,7 +366,8 @@ function DialogFooterContent({
         </Button>
       )}
 
-      {data.controlStatus !== 'idle' && (
+      {(data.controlStatus === 'downloading' ||
+        data.controlStatus === 'downloadCompleted') && (
         <Button
           type='button'
           variant='destructive'

--- a/client/src/components/TooltipedIcon.tsx
+++ b/client/src/components/TooltipedIcon.tsx
@@ -1,0 +1,20 @@
+import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
+
+export function TooltipedIcon({
+  icon,
+  text,
+  action,
+}: {
+  icon: React.ReactNode;
+  text: string;
+  action?: () => void;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger>{icon}</TooltipTrigger>
+      <TooltipContent onClick={action} className='text-xs'>
+        <p>{text}</p>
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/client/src/components/TorrentTable/TorrentTableData.tsx
+++ b/client/src/components/TorrentTable/TorrentTableData.tsx
@@ -13,6 +13,8 @@ import TrackerLogo from '../TrackerLogo';
 import { useTorrentStore } from '@/stores/torrentStore';
 import { cn, formatETA } from '@/lib/utils';
 import type { NormalizedTorrent } from '@ctrl/shared-torrent';
+import { Pause } from 'lucide-react';
+import { TooltipedIcon } from '../TooltipedIcon';
 
 export function TorrentTableData() {
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -91,6 +93,7 @@ function DataTableRow({
 
   const downloading = status?.state === 'downloading';
   const downloadPaused = status?.state === 'paused';
+  const trackingPaused = item.controlStatus === 'paused';
 
   const downloadedFiles = filterMediaFiles(item.files as string[]).length;
   return (
@@ -111,21 +114,35 @@ function DataTableRow({
       <TableCell className='w-12'>
         <TrackerLogo tracker={item.tracker || ''} />
       </TableCell>
-      <TableCell className='font-bold'>{item.title}</TableCell>
-      <TableCell className='font-mono text-zinc-300'>
+      <TableCell
+        className={cn(
+          'font-bold',
+          trackingPaused && 'text-muted-foreground/40'
+        )}>
+        {item.title}
+      </TableCell>
+      <TableCell
+        className={cn(
+          'font-mono text-zinc-300',
+          trackingPaused && 'text-muted-foreground/40'
+        )}>
         <span className='p-1 bg-muted rounded-md text-xs font-bold min-w-7 flex w-fit items-center justify-center'>
           {item.season}
         </span>
       </TableCell>
-      <TableCell className='font-mono text-zinc-300'>
+      <TableCell
+        className={cn(
+          'font-mono text-zinc-300',
+          trackingPaused && 'text-muted-foreground/40'
+        )}>
         {(item.haveEpisodes as number[]).length} of {item.totalEpisodes}
       </TableCell>
       <TableCell
         className={cn(
-          'font-mono',
-          (item.trackedEpisodes as number[]).length > 0
-            ? 'text-zinc-300'
-            : 'text-muted-foreground/40'
+          'font-mono text-muted-foreground/40',
+          (item.trackedEpisodes as number[]).length > 0 &&
+            !trackingPaused &&
+            'text-zinc-300'
         )}>
         {(item.trackedEpisodes as number[]).length} of {item.totalEpisodes}
       </TableCell>
@@ -139,9 +156,9 @@ function DataTableRow({
       <TableCell
         className={cn(
           'font-mono text-nowrap',
-          new Date(item.updatedAt).toDateString() === new Date().toDateString()
-            ? 'text-green-500'
-            : 'text-zinc-300'
+          new Date(item.updatedAt).toDateString() ===
+            new Date().toDateString() && 'text-green-500',
+          trackingPaused && 'text-muted-foreground/40'
         )}>
         {item.updatedAt
           ? new Date(item.updatedAt).toLocaleDateString('en-GB', {
@@ -156,9 +173,16 @@ function DataTableRow({
       <TableCell className='font-mono text-zinc-300'>
         {status?.eta &&
         status?.state === 'downloading' &&
+        !trackingPaused &&
         Number(status?.eta) > 0
           ? 'ETA: ' + formatETA(Number(status?.eta))
           : ''}
+        {trackingPaused && (
+          <TooltipedIcon
+            icon={<Pause className='w-4 h-4 cursor-pointer text-orange-500' />}
+            text='Tracking paused'
+          />
+        )}
       </TableCell>
       {item.controlStatus === 'downloading' && (
         <div

--- a/client/src/components/TorrentTable/TorrentTableData.tsx
+++ b/client/src/components/TorrentTable/TorrentTableData.tsx
@@ -90,7 +90,7 @@ function DataTableRow({
   };
 
   const downloading = status?.state === 'downloading';
-  const paused = status?.state === 'paused';
+  const downloadPaused = status?.state === 'paused';
 
   const downloadedFiles = filterMediaFiles(item.files as string[]).length;
   return (
@@ -105,7 +105,8 @@ function DataTableRow({
         'relative cursor-pointer',
         downloading &&
           'bg-green-500/10 animate-pulse animate-infinite animate-slow',
-        paused && 'bg-zinc-300/10 animate-pulse animate-infinite animate-slow'
+        downloadPaused &&
+          'bg-zinc-300/10 animate-pulse animate-infinite animate-slow'
       )}>
       <TableCell className='w-12'>
         <TrackerLogo tracker={item.tracker || ''} />

--- a/client/src/components/ui/tooltip.tsx
+++ b/client/src/components/ui/tooltip.tsx
@@ -1,0 +1,59 @@
+import * as React from "react"
+import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+
+import { cn } from "@/lib/utils"
+
+function TooltipProvider({
+  delayDuration = 0,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delayDuration={delayDuration}
+      {...props}
+    />
+  )
+}
+
+function Tooltip({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return (
+    <TooltipProvider>
+      <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+    </TooltipProvider>
+  )
+}
+
+function TooltipTrigger({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 0,
+  children,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        data-slot="tooltip-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-foreground text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <TooltipPrimitive.Arrow className="bg-foreground fill-foreground z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  )
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/server/src/db/app/app-schema.ts
+++ b/server/src/db/app/app-schema.ts
@@ -2,6 +2,15 @@ import { index, int, sqliteTable, text } from 'drizzle-orm/sqlite-core';
 import { sql } from 'drizzle-orm';
 import { trackersConf } from '@server/shared/trackers-conf';
 
+export const controlStatuses = [
+  'idle',
+  'downloadRequested',
+  'downloading',
+  'downloadCompleted',
+  'processing',
+  'paused',
+] as const;
+
 export const torrentItems = sqliteTable(
   'torrent_items',
   {
@@ -26,13 +35,7 @@ export const torrentItems = sqliteTable(
       .notNull(),
     transmissionId: text('transmission_id').unique(),
     controlStatus: text('control_status', {
-      enum: [
-        'idle',
-        'donwloadRequested',
-        'downloading',
-        'downloadCompleted',
-        'processing',
-      ],
+      enum: controlStatuses,
     })
       .default('idle')
       .notNull(),

--- a/server/src/features/torrent-item/torrent-item.port.ts
+++ b/server/src/features/torrent-item/torrent-item.port.ts
@@ -17,4 +17,14 @@ export interface TorrentItemPort {
   markAsDownloadRequested(): Promise<void>;
 
   updateTrackedEpisodes(episodes: number[]): Promise<void>;
+
+  markAsTrackedAll(): Promise<void>;
+
+  delete(withFiles?: boolean): Promise<void>;
+
+  markAsPaused(): Promise<void>;
+
+  markAsIdle(): Promise<void>;
+
+  deleteFileEpisode(filePath: string): Promise<void>;
 }

--- a/server/src/features/torrent-item/torrent-item.service.ts
+++ b/server/src/features/torrent-item/torrent-item.service.ts
@@ -146,6 +146,20 @@ export class TorrentItem implements TorrentItemPort {
     });
   }
 
+  async markAsPaused() {
+    if (!this.id) throw new Error('ID is not defined');
+    await this.repo.update(this.id, {
+      controlStatus: 'paused',
+    });
+  }
+
+  async markAsIdle() {
+    if (!this.id) throw new Error('ID is not defined');
+    await this.repo.update(this.id, {
+      controlStatus: 'idle',
+    });
+  }
+
   async deleteFileEpisode(filePath: string) {
     if (!this.id) throw new Error('ID is not defined');
     if (!this.databaseData) await this.getById();

--- a/server/src/features/torrent-item/torrent-item.service.ts
+++ b/server/src/features/torrent-item/torrent-item.service.ts
@@ -117,7 +117,7 @@ export class TorrentItem implements TorrentItemPort {
     if (!this.databaseData)
       throw new Error('No database data on markAsDownloadRequested');
     const row = await this.repo.update(this.databaseData.id, {
-      controlStatus: 'donwloadRequested',
+      controlStatus: 'downloadRequested',
     });
     this.databaseData = row ?? null;
   }

--- a/server/src/features/torrent-item/torrent-item.types.ts
+++ b/server/src/features/torrent-item/torrent-item.types.ts
@@ -1,5 +1,6 @@
 import type { TrackerDataAdapter } from '@server/external/adapters/tracker-data';
 import type { TorrentItemRepo } from './torrent-item.repo';
+import type { controlStatuses } from '@server/db/app/app-schema';
 
 export type TorrentItemDto = {
   id: number;
@@ -14,7 +15,7 @@ export type TorrentItemDto = {
   totalEpisodes: number | null;
   trackedEpisodes: number[];
   magnet: string | null;
-  controlStatus: string;
+  controlStatus: (typeof controlStatuses)[number];
   createdAt: number;
   updatedAt: number;
 };

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -22,6 +22,7 @@ import { jackettVerifyRoute } from './routes/jackett.verify';
 import { systemExitRoute } from './routes/system.exit';
 import { trackersKinozalVerifyRoute } from './routes/trackers.kinozal.verify';
 import { getUserCount } from './lib/utils';
+import { torrentsPauseToggleRoute } from './routes/torrents.pause-toggle';
 
 export const app = new Hono<{
   Variables: {
@@ -85,7 +86,7 @@ export const routes = app
   .route('/torrents/add', torrentsAddRoute)
   .route('/torrents/:id/delete', torrentsDeleteRoute)
   .route('/torrents/:id/save-tracked-ep', torrentsSaveTrackedEpRoute)
-
+  .route('/torrents/:id/pause-toggle', torrentsPauseToggleRoute)
   .route('/torrent-client/:id/add', torrentClientAddRoute)
   .route('/torrent-client/:id/delete', torrentClientDeleteRoute);
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -11,7 +11,7 @@ import { torrentsStatusRoute } from './routes/torrents.status';
 import { torrentsAddRoute } from './routes/torrents.add';
 import { torrentsDeleteRoute } from './routes/torrents.$id.delete';
 import { torrentsRoute } from './routes/torrents';
-import { torrentsSaveRoute } from './routes/torrents.save';
+import { torrentsSaveTrackedEpRoute } from './routes/torrents.save-tracked-ep';
 import { torrentClientAddRoute } from './routes/torrent-client.$id.add';
 import { torrentClientDeleteRoute } from './routes/torrent-client.$id.delete';
 import { runMigrations } from '../scripts/migrate';
@@ -84,7 +84,8 @@ export const routes = app
   .route('/torrents/status', torrentsStatusRoute)
   .route('/torrents/add', torrentsAddRoute)
   .route('/torrents/:id/delete', torrentsDeleteRoute)
-  .route('/torrents/:id/save', torrentsSaveRoute)
+  .route('/torrents/:id/save-tracked-ep', torrentsSaveTrackedEpRoute)
+
   .route('/torrent-client/:id/add', torrentClientAddRoute)
   .route('/torrent-client/:id/delete', torrentClientDeleteRoute);
 

--- a/server/src/routes/torrents.pause-toggle.ts
+++ b/server/src/routes/torrents.pause-toggle.ts
@@ -1,0 +1,56 @@
+import { Hono } from 'hono/tiny';
+import type { ApiResponse } from 'shared/dist';
+import { TorrentItem } from '@server/features/torrent-item/torrent-item.service';
+import { z } from 'zod';
+import logger from '@server/lib/logger';
+import { zValidator } from '@hono/zod-validator';
+import { handleZodValidation } from '@server/lib/validation';
+
+const paramSchema = z.object({
+  id: z.coerce.number().min(1),
+});
+
+export const torrentsPauseToggleRoute = new Hono().put(
+  '/',
+  zValidator('param', paramSchema, handleZodValidation),
+
+  async (c) => {
+    const { id } = c.req.valid('param');
+    try {
+      const ti = new TorrentItem({
+        id,
+      });
+      await ti.getById();
+
+      const isPaused = ti.databaseData?.controlStatus === 'paused';
+      const isIdle = ti.databaseData?.controlStatus === 'idle';
+
+      if (!isIdle && !isPaused) {
+        const response: ApiResponse<null> = {
+          success: false,
+          message: 'Torrent is not idle or paused, cannot toggle pause status',
+        };
+        return c.json(response, 400);
+      }
+
+      if (!isPaused) {
+        await ti.markAsPaused();
+      } else {
+        await ti.markAsIdle();
+      }
+
+      const response: ApiResponse<null> = {
+        success: true,
+        message: `Torrent tracking ${!isPaused ? 'paused' : 'unpaused'}`,
+      };
+      return c.json(response);
+    } catch (e) {
+      logger.error(e);
+      const response: ApiResponse<null> = {
+        success: false,
+        message: (e as Error).message,
+      };
+      return c.json(response, 400);
+    }
+  }
+);

--- a/server/src/routes/torrents.save-tracked-ep.ts
+++ b/server/src/routes/torrents.save-tracked-ep.ts
@@ -14,7 +14,7 @@ const jsonSchema = z.object({
   episodes: z.number({ error: 'Episodes must be a number' }).array(),
 });
 
-export const torrentsSaveRoute = new Hono().post(
+export const torrentsSaveTrackedEpRoute = new Hono().post(
   '/',
   zValidator('param', paramSchema, handleZodValidation),
   zValidator('json', jsonSchema, handleZodValidation),

--- a/server/src/workers/download-worker.ts
+++ b/server/src/workers/download-worker.ts
@@ -185,7 +185,7 @@ export class DownloadWorker {
     if (!rows) return;
     for (const row of rows) {
       switch (row.controlStatus) {
-        case 'donwloadRequested':
+        case 'downloadRequested':
           await this.startDownload(row);
           break;
         case 'downloading':

--- a/server/src/workers/download-worker.ts
+++ b/server/src/workers/download-worker.ts
@@ -163,7 +163,9 @@ export class DownloadWorker {
           logger.warn(`[DownloadWorker] File not found: ${file}`);
         } else {
           logger.error(
-            `[DownloadWorker] Unexpected error while statting ${file}: ${String(err)}`
+            `[DownloadWorker] Unexpected error while statting ${file}: ${String(
+              err
+            )}`
           );
           existingFiles.push(file);
         }
@@ -195,6 +197,7 @@ export class DownloadWorker {
           await this.processCompletedDownload(row);
           break;
         case 'idle':
+        case 'paused':
           if (
             process.env.HOOP_LAST_SYNC &&
             parseInt(process.env.HOOP_LAST_SYNC) <= Date.now()

--- a/server/src/workers/workers.repo.ts
+++ b/server/src/workers/workers.repo.ts
@@ -28,7 +28,7 @@ export class WorkersRepo {
       .from(torrentItems)
       .where(
         or(
-          eq(torrentItems.controlStatus, 'donwloadRequested'),
+          eq(torrentItems.controlStatus, 'downloadRequested'),
           eq(torrentItems.controlStatus, 'downloading'),
           eq(torrentItems.controlStatus, 'downloadCompleted'),
           eq(torrentItems.controlStatus, 'idle')

--- a/server/src/workers/workers.repo.ts
+++ b/server/src/workers/workers.repo.ts
@@ -31,7 +31,8 @@ export class WorkersRepo {
           eq(torrentItems.controlStatus, 'downloadRequested'),
           eq(torrentItems.controlStatus, 'downloading'),
           eq(torrentItems.controlStatus, 'downloadCompleted'),
-          eq(torrentItems.controlStatus, 'idle')
+          eq(torrentItems.controlStatus, 'idle'),
+          eq(torrentItems.controlStatus, 'paused')
         )
       );
 

--- a/server/test/download-worker.test.ts
+++ b/server/test/download-worker.test.ts
@@ -232,7 +232,7 @@ describe('DownloadWorker', () => {
     const repo = new RepoMock();
     const worker = new DownloadWorker({ repo: repo as unknown as never });
 
-    const req = { ...item, controlStatus: 'donwloadRequested' as const };
+    const req = { ...item, controlStatus: 'downloadRequested' as const };
     const dl = { ...item, id: 2, controlStatus: 'downloading' as const };
     const done = { ...item, id: 3, controlStatus: 'downloadCompleted' as const };
 

--- a/server/test/torrent-item.service.test.ts
+++ b/server/test/torrent-item.service.test.ts
@@ -45,7 +45,10 @@ vi.mock('@server/features/file-management/file-management.service', () => ({
 
 type RepoMock = {
   findAll: ReturnType<
-    typeof vi.fn<[number, number], Promise<{ items: DbTorrentItem[]; total: number }>>
+    typeof vi.fn<
+      [number, number],
+      Promise<{ items: DbTorrentItem[]; total: number }>
+    >
   >;
   findById: ReturnType<typeof vi.fn<[number], Promise<DbTorrentItem | null>>>;
   upsert: ReturnType<
@@ -58,15 +61,17 @@ type RepoMock = {
       Promise<DbTorrentItem | undefined>
     >
   >;
-} &
-  Pick<
-    TorrentItemRepo,
-    'findAll' | 'findById' | 'upsert' | 'deleteById' | 'update'
-  >;
+} & Pick<
+  TorrentItemRepo,
+  'findAll' | 'findById' | 'upsert' | 'deleteById' | 'update'
+>;
 
 function createRepoMock(): RepoMock {
   const repo = {
-    findAll: vi.fn<[number, number], Promise<{ items: DbTorrentItem[]; total: number }>>(),
+    findAll: vi.fn<
+      [number, number],
+      Promise<{ items: DbTorrentItem[]; total: number }>
+    >(),
     findById: vi.fn<[number], Promise<DbTorrentItem | null>>(),
     upsert: vi.fn<[DbTorrentItemInsert], Promise<DbTorrentItem | undefined>>(),
     deleteById: vi.fn<[number], Promise<void>>(),
@@ -149,7 +154,10 @@ describe('TorrentItem service', () => {
       total: 5,
     });
 
-    const item = new TorrentItem({ url: 'https://kinozal.tv/details.php?id=1', repo });
+    const item = new TorrentItem({
+      url: 'https://kinozal.tv/details.php?id=1',
+      repo,
+    });
     const result = await item.getAll(1, 2);
 
     expect(result.total).toBe(5);
@@ -278,7 +286,10 @@ describe('TorrentItem service', () => {
   it('marks torrent as download requested using cached data', async () => {
     const repo = createRepoMock();
     const dbItem = createDbTorrentItem();
-    repo.update.mockResolvedValue({ ...dbItem, controlStatus: 'donwloadRequested' });
+    repo.update.mockResolvedValue({
+      ...dbItem,
+      controlStatus: 'downloadRequested',
+    });
 
     const item = new TorrentItem({ id: dbItem.id, repo });
     item.databaseData = dbItem;
@@ -286,9 +297,9 @@ describe('TorrentItem service', () => {
     await item.markAsDownloadRequested();
 
     expect(repo.update).toHaveBeenCalledWith(dbItem.id, {
-      controlStatus: 'donwloadRequested',
+      controlStatus: 'downloadRequested',
     });
-    expect(item.databaseData?.controlStatus).toBe('donwloadRequested');
+    expect(item.databaseData?.controlStatus).toBe('downloadRequested');
   });
 
   it('marks all episodes as tracked', async () => {


### PR DESCRIPTION
## Summary
- add a PUT /api/torrents/:id/pause-toggle route backed by TorrentItem helpers
- surface pause toggle controls and paused state indicator in the client UI
- expand schema and test coverage for the new control status handling

## Rationale
- allow operators to pause and resume torrent tracking without removing the item

## Changes
- add TorrentItem#markAsPaused/#markAsIdle and expose controlStatuses enum via schema
- register the pause-toggle route and ensure workers respect paused downloads
- update the dashboard dialog and table to trigger the new RPC and display state
- rename the tracked episodes save route for clarity and extend unit/integration tests

## Testing
- bun run lint
- bun run test
- bun run build
- (client) bunx tsc --noEmit --strict --project tsconfig.app.json
- (server) bunx tsc --noEmit --strict --project tsconfig.json
