### PR TITLE
Add FlareSolverr bypass settings

### DIFF
--- a/client/src/components/settings/FlareSolverrSettings.tsx
+++ b/client/src/components/settings/FlareSolverrSettings.tsx
@@ -1,0 +1,182 @@
+import customSonner from '@/components/CustomSonner';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { rpc } from '@/lib/rpc';
+import type { DbUserSettings } from '@server/db/app/app-schema';
+import { Loader2 } from 'lucide-react';
+import { useState } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+
+type FlareSolverrSettingsProps = {
+  enabled: boolean;
+  serverUrl: string;
+  timeoutSeconds: number;
+  setData: Dispatch<SetStateAction<DbUserSettings | null | undefined>>;
+};
+
+export default function FlareSolverrSettings({
+  enabled,
+  serverUrl,
+  timeoutSeconds,
+  setData,
+}: FlareSolverrSettingsProps) {
+  const [isTestingConnection, setIsTestingConnection] = useState(false);
+
+  const handleTestConnection = async () => {
+    if (!enabled) {
+      customSonner({ variant: 'error', text: 'FlareSolverr is disabled' });
+      return;
+    }
+
+    if (!serverUrl) {
+      customSonner({ variant: 'error', text: 'FlareSolverr URL is required' });
+      return;
+    }
+
+    if (!isValidUrl(serverUrl)) {
+      customSonner({
+        variant: 'error',
+        text: 'Invalid FlareSolverr URL. It should include the protocol.',
+      });
+      return;
+    }
+
+    try {
+      setIsTestingConnection(true);
+      const response = await rpc.api.flaresolverr.verify.$post({
+        json: {
+          flaresolverrUrl: serverUrl,
+          timeoutSeconds,
+        },
+      });
+      const payload = await response.json();
+
+      if (!response.ok || !payload?.success) {
+        customSonner({
+          variant: 'error',
+          text: payload?.message ?? 'Failed to test FlareSolverr connection',
+        });
+        return;
+      }
+
+      customSonner({ text: 'FlareSolverr connection successful' });
+    } catch (error) {
+      const description =
+        error instanceof Error ? error.message : String(error);
+      customSonner({
+        variant: 'error',
+        text: 'Failed to test FlareSolverr connection',
+        description,
+      });
+    } finally {
+      setIsTestingConnection(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-row gap-4">
+      <div className="flex flex-col gap-2 w-1/3">
+        <h2 className="text-xl font-black text-zinc-300">
+          FlareSolverr Settings
+        </h2>
+      </div>
+
+      <div className="flex flex-col gap-10 w-2/3">
+        <div className="flex flex-col gap-4">
+          <div className="flex items-center gap-3">
+            <Checkbox
+              id="flaresolverr-enabled"
+              checked={enabled}
+              onCheckedChange={(checked) =>
+                setData((data) => {
+                  if (!data) return data;
+                  return {
+                    ...data,
+                    flaresolverrEnabled: checked === true,
+                  };
+                })
+              }
+            />
+            <Label htmlFor="flaresolverr-enabled">Enable FlareSolverr</Label>
+          </div>
+        </div>
+
+        <div className="flex flex-row w-full gap-6 border-t border-zinc-800 pt-6">
+          <div className="flex flex-col w-1/2 gap-4">
+            <h3 className="text-lg font-extrabold">Server URL</h3>
+            <Input
+              className="font-mono text-base"
+              placeholder="http://localhost:8191"
+              value={serverUrl}
+              disabled={!enabled}
+              onChange={(event) =>
+                setData((data) => {
+                  if (!data) return data;
+                  return {
+                    ...data,
+                    flaresolverrUrl: event.target.value,
+                  };
+                })
+              }
+            />
+          </div>
+          <div className="flex flex-col w-1/2 gap-2 justify-end">
+            <Button
+              variant="secondary"
+              className="font-bold"
+              onClick={handleTestConnection}
+              disabled={!enabled || isTestingConnection}
+            >
+              {isTestingConnection ? (
+                <Loader2 className="w-4 h-4 animate-spin" />
+              ) : (
+                'Test Connection'
+              )}
+            </Button>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-4 border-t border-zinc-800 pt-6">
+          <h3 className="text-lg font-extrabold">Timeout</h3>
+          <Input
+            className="w-40 font-mono text-base"
+            type="number"
+            min={1}
+            max={300}
+            value={timeoutSeconds}
+            disabled={!enabled}
+            onChange={(event) =>
+              setData((data) => {
+                if (!data) return data;
+                return {
+                  ...data,
+                  flaresolverrTimeoutSeconds: parseTimeoutSeconds(
+                    event.target.value,
+                  ),
+                };
+              })
+            }
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// Helpers
+
+function isValidUrl(value: string): boolean {
+  try {
+    return Boolean(new URL(value));
+  } catch {
+    return false;
+  }
+}
+
+function parseTimeoutSeconds(value: string): number {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed)) return 60;
+  return Math.min(Math.max(parsed, 1), 300);
+}

--- a/client/src/routes/dashboard/settings.tsx
+++ b/client/src/routes/dashboard/settings.tsx
@@ -1,5 +1,6 @@
 import customSonner from '@/components/CustomSonner';
 import GeneralSettings from '@/components/settings/GeneralSettings';
+import FlareSolverrSettings from '@/components/settings/FlareSolverrSettings';
 import JackettSettings from '@/components/settings/JackettSettings';
 import NotificationSettings from '@/components/settings/NotificationSettings';
 import SettingsMenu from '@/components/settings/SettingsMenu';
@@ -36,7 +37,7 @@ export default function Settings() {
 
           if (typeof next === 'function') {
             const updater = next as (
-              prevState: DbUserSettings | null | undefined
+              prevState: DbUserSettings | null | undefined,
             ) => DbUserSettings | null | undefined;
             const updated = updater(resolvedCurrentData);
             return updated ?? undefined;
@@ -45,7 +46,7 @@ export default function Settings() {
           return next ?? undefined;
         });
       },
-      [settingsData]
+      [settingsData],
     );
 
   const handleSave = async () => {
@@ -66,11 +67,11 @@ export default function Settings() {
   if (isLoadingSettings) {
     return (
       <>
-        <div className='flex flex-col w-full'>
+        <div className="flex flex-col w-full">
           <SettingsMenu />
         </div>
-        <div className='flex flex-col gap-4 mx-auto mt-[30vh]'>
-          <Loader2 className='w-10 h-10 animate-spin' />
+        <div className="flex flex-col gap-4 mx-auto mt-[30vh]">
+          <Loader2 className="w-10 h-10 animate-spin" />
         </div>
       </>
     );
@@ -91,32 +92,40 @@ export default function Settings() {
         syncInterval={data?.syncInterval ?? 0}
         setData={setData}
       />
-      <Separator className='my-12' />
+      <Separator className="my-12" />
       <TorrentClientSettings
         downloadDir={data?.downloadDir ?? ''}
         mediaDir={data?.mediaDir ?? ''}
         deleteAfterDownload={data?.deleteAfterDownload ?? false}
         setData={setData}
       />
-      <Separator className='my-12' />
+      <Separator className="my-12" />
       <NotificationSettings
         telegramId={data?.telegramId ?? 0}
         botToken={data?.botToken ?? ''}
         setData={setData}
       />
-      <Separator className='my-12' />
+      <Separator className="my-12" />
       <JackettSettings
         jackettUrl={data?.jackettUrl ?? ''}
         jackettApiKey={data?.jackettApiKey ?? ''}
         setData={setData}
       />
-      <Separator className='my-12' />
+      <Separator className="my-12" />
+      <FlareSolverrSettings
+        enabled={data?.flaresolverrEnabled ?? false}
+        serverUrl={data?.flaresolverrUrl ?? ''}
+        timeoutSeconds={data?.flaresolverrTimeoutSeconds ?? 60}
+        setData={setData}
+      />
+      <Separator className="my-12" />
       <Button
-        className='w-fit my-10 flex font-extrabold ml-auto'
-        size='lg'
-        onClick={handleSave}>
+        className="w-fit my-10 flex font-extrabold ml-auto"
+        size="lg"
+        onClick={handleSave}
+      >
         {isSavingSettings ? (
-          <Loader2 className='w-4 h-4 animate-spin' />
+          <Loader2 className="w-4 h-4 animate-spin" />
         ) : (
           'Save Settings'
         )}

--- a/server/src/db/app/app-schema.ts
+++ b/server/src/db/app/app-schema.ts
@@ -44,7 +44,7 @@ export const torrentItems = sqliteTable(
     }).notNull(),
     errorMessage: text('error_message'),
   },
-  (t) => [index('tracker_index').on(t.tracker)]
+  (t) => [index('tracker_index').on(t.tracker)],
 );
 
 export const userSettings = sqliteTable('user_settings', {
@@ -61,6 +61,13 @@ export const userSettings = sqliteTable('user_settings', {
   jackettUrl: text('jackett_url'),
   kinozalUsername: text('kinozal_username'),
   kinozalPassword: text('kinozal_password'),
+  flaresolverrEnabled: int('flaresolverr_enabled', {
+    mode: 'boolean',
+  }).default(false),
+  flaresolverrUrl: text('flaresolverr_url'),
+  flaresolverrTimeoutSeconds: int('flaresolverr_timeout_seconds')
+    .default(60)
+    .notNull(),
 });
 
 export type DbTorrentItem = typeof torrentItems.$inferSelect;

--- a/server/src/db/migrations/0001_add_flaresolverr_settings.sql
+++ b/server/src/db/migrations/0001_add_flaresolverr_settings.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `user_settings` ADD `flaresolverr_enabled` integer DEFAULT false;--> statement-breakpoint
+ALTER TABLE `user_settings` ADD `flaresolverr_url` text;

--- a/server/src/db/migrations/0002_add_flaresolverr_timeout.sql
+++ b/server/src/db/migrations/0002_add_flaresolverr_timeout.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `user_settings` ADD `flaresolverr_timeout_seconds` integer DEFAULT 60 NOT NULL;

--- a/server/src/db/migrations/meta/0001_snapshot.json
+++ b/server/src/db/migrations/meta/0001_snapshot.json
@@ -1,0 +1,607 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "4ab4daa6-2fa1-42db-a2f7-6a277113f30b",
+  "prevId": "990d80e5-abff-4b0a-943b-b9d30c40f5a5",
+  "tables": {
+    "torrent_items": {
+      "name": "torrent_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "tracker_id": {
+          "name": "tracker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_title": {
+          "name": "raw_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "magnet": {
+          "name": "magnet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "season": {
+          "name": "season",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tracked_episodes": {
+          "name": "tracked_episodes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "have_episodes": {
+          "name": "have_episodes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "total_episodes": {
+          "name": "total_episodes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "files": {
+          "name": "files",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        },
+        "transmission_id": {
+          "name": "transmission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "control_status": {
+          "name": "control_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'idle'"
+        },
+        "tracker": {
+          "name": "tracker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "torrent_items_tracker_id_unique": {
+          "name": "torrent_items_tracker_id_unique",
+          "columns": [
+            "tracker_id"
+          ],
+          "isUnique": true
+        },
+        "torrent_items_url_unique": {
+          "name": "torrent_items_url_unique",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        },
+        "torrent_items_transmission_id_unique": {
+          "name": "torrent_items_transmission_id_unique",
+          "columns": [
+            "transmission_id"
+          ],
+          "isUnique": true
+        },
+        "tracker_index": {
+          "name": "tracker_index",
+          "columns": [
+            "tracker"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "telegram_id": {
+          "name": "telegram_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bot_token": {
+          "name": "bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "download_dir": {
+          "name": "download_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_dir": {
+          "name": "media_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delete_after_download": {
+          "name": "delete_after_download",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "sync_interval": {
+          "name": "sync_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "jackett_api_key": {
+          "name": "jackett_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "jackett_url": {
+          "name": "jackett_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kinozal_username": {
+          "name": "kinozal_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kinozal_password": {
+          "name": "kinozal_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "flaresolverr_enabled": {
+          "name": "flaresolverr_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "flaresolverr_url": {
+          "name": "flaresolverr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/server/src/db/migrations/meta/0002_snapshot.json
+++ b/server/src/db/migrations/meta/0002_snapshot.json
@@ -1,0 +1,615 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "713f4bb9-fe9f-491f-8103-85891f03e848",
+  "prevId": "4ab4daa6-2fa1-42db-a2f7-6a277113f30b",
+  "tables": {
+    "torrent_items": {
+      "name": "torrent_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "tracker_id": {
+          "name": "tracker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_title": {
+          "name": "raw_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "magnet": {
+          "name": "magnet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "season": {
+          "name": "season",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tracked_episodes": {
+          "name": "tracked_episodes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "have_episodes": {
+          "name": "have_episodes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "total_episodes": {
+          "name": "total_episodes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "files": {
+          "name": "files",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        },
+        "transmission_id": {
+          "name": "transmission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "control_status": {
+          "name": "control_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'idle'"
+        },
+        "tracker": {
+          "name": "tracker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "torrent_items_tracker_id_unique": {
+          "name": "torrent_items_tracker_id_unique",
+          "columns": [
+            "tracker_id"
+          ],
+          "isUnique": true
+        },
+        "torrent_items_url_unique": {
+          "name": "torrent_items_url_unique",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        },
+        "torrent_items_transmission_id_unique": {
+          "name": "torrent_items_transmission_id_unique",
+          "columns": [
+            "transmission_id"
+          ],
+          "isUnique": true
+        },
+        "tracker_index": {
+          "name": "tracker_index",
+          "columns": [
+            "tracker"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "telegram_id": {
+          "name": "telegram_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bot_token": {
+          "name": "bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "download_dir": {
+          "name": "download_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_dir": {
+          "name": "media_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delete_after_download": {
+          "name": "delete_after_download",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "sync_interval": {
+          "name": "sync_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "jackett_api_key": {
+          "name": "jackett_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "jackett_url": {
+          "name": "jackett_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kinozal_username": {
+          "name": "kinozal_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kinozal_password": {
+          "name": "kinozal_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "flaresolverr_enabled": {
+          "name": "flaresolverr_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "flaresolverr_url": {
+          "name": "flaresolverr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "flaresolverr_timeout_seconds": {
+          "name": "flaresolverr_timeout_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 60
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/server/src/db/migrations/meta/_journal.json
+++ b/server/src/db/migrations/meta/_journal.json
@@ -8,6 +8,20 @@
       "when": 1758535572607,
       "tag": "0000_sloppy_red_ghost",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1782105639366,
+      "tag": "0001_add_flaresolverr_settings",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1782107364269,
+      "tag": "0002_add_flaresolverr_timeout",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/external/adapters/tracker-data/flaresolverr.ts
+++ b/server/src/external/adapters/tracker-data/flaresolverr.ts
@@ -42,7 +42,7 @@ export async function fetchWithFlareSolverr(params: {
   timeout: number;
   cookies: string;
 }): Promise<FlareSolverrSolution> {
-  const endpoint = new URL('/v1', normalizeServerUrl(params.serverUrl));
+  const endpoint = new URL('v1', normalizeServerUrl(params.serverUrl));
   const payload: RequestGetPayload = {
     cmd: 'request.get',
     url: params.targetUrl,
@@ -83,7 +83,7 @@ export async function verifyFlareSolverr(params: {
   serverUrl: string;
   timeout: number;
 }): Promise<void> {
-  const endpoint = new URL('/v1', normalizeServerUrl(params.serverUrl));
+  const endpoint = new URL('v1', normalizeServerUrl(params.serverUrl));
   const payload: SessionsListPayload = {
     cmd: 'sessions.list',
   };

--- a/server/src/external/adapters/tracker-data/flaresolverr.ts
+++ b/server/src/external/adapters/tracker-data/flaresolverr.ts
@@ -1,0 +1,140 @@
+import { customFetch } from '@server/shared/custom-fetch';
+
+export type FlareSolverrCookie = {
+  name: string;
+  value: string;
+  domain?: string;
+  path?: string;
+  expires?: number;
+  httpOnly?: boolean;
+  secure?: boolean;
+  session?: boolean;
+  sameSite?: string;
+};
+
+export type FlareSolverrSolution = {
+  status: number;
+  response: string;
+  cookies: FlareSolverrCookie[];
+  userAgent: string;
+};
+
+type FlareSolverrResponse = {
+  status: string;
+  message?: string;
+  solution?: FlareSolverrSolution;
+};
+
+type RequestGetPayload = {
+  cmd: 'request.get';
+  url: string;
+  maxTimeout: number;
+  cookies?: FlareSolverrCookie[];
+};
+
+type SessionsListPayload = {
+  cmd: 'sessions.list';
+};
+
+export async function fetchWithFlareSolverr(params: {
+  serverUrl: string;
+  targetUrl: string;
+  timeout: number;
+  cookies: string;
+}): Promise<FlareSolverrSolution> {
+  const endpoint = new URL('/v1', normalizeServerUrl(params.serverUrl));
+  const payload: RequestGetPayload = {
+    cmd: 'request.get',
+    url: params.targetUrl,
+    maxTimeout: params.timeout,
+  };
+  const parsedCookies = parseCookieHeader(params.cookies);
+
+  if (parsedCookies.length > 0) {
+    payload.cookies = parsedCookies;
+  }
+
+  const response = await customFetch(
+    endpoint.href,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    },
+    params.timeout + 5_000,
+    1,
+  );
+  const body = (await response.json()) as FlareSolverrResponse;
+
+  if (!response.ok || body.status !== 'ok' || !body.solution) {
+    throw new Error(body.message || 'FlareSolverr request failed');
+  }
+
+  if (!body.solution.response) {
+    throw new Error('FlareSolverr response body is empty');
+  }
+
+  return body.solution;
+}
+
+export async function verifyFlareSolverr(params: {
+  serverUrl: string;
+  timeout: number;
+}): Promise<void> {
+  const endpoint = new URL('/v1', normalizeServerUrl(params.serverUrl));
+  const payload: SessionsListPayload = {
+    cmd: 'sessions.list',
+  };
+  const response = await customFetch(
+    endpoint.href,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    },
+    params.timeout,
+    1,
+  );
+  const body = (await response.json()) as FlareSolverrResponse;
+
+  if (!response.ok || body.status !== 'ok') {
+    throw new Error(body.message || 'FlareSolverr connection failed');
+  }
+}
+
+export function buildCookieHeader(cookies: FlareSolverrCookie[]): string {
+  return cookies
+    .filter((cookie) => cookie.name && cookie.value)
+    .map((cookie) => `${cookie.name}=${cookie.value}`)
+    .join('; ');
+}
+
+function normalizeServerUrl(serverUrl: string): string {
+  const trimmed = serverUrl.trim();
+  if (!trimmed) {
+    throw new Error('FlareSolverr URL is required');
+  }
+
+  return trimmed.endsWith('/') ? trimmed : `${trimmed}/`;
+}
+
+function parseCookieHeader(cookieHeader: string): FlareSolverrCookie[] {
+  return cookieHeader
+    .split(';')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => {
+      const separatorIndex = entry.indexOf('=');
+      if (separatorIndex <= 0) return null;
+
+      return {
+        name: entry.slice(0, separatorIndex),
+        value: entry.slice(separatorIndex + 1),
+      };
+    })
+    .filter((cookie): cookie is FlareSolverrCookie => cookie !== null);
+}

--- a/server/src/external/adapters/tracker-data/tracker-data.adapter.ts
+++ b/server/src/external/adapters/tracker-data/tracker-data.adapter.ts
@@ -12,11 +12,7 @@ import { TrackerAuth } from './tracker-data.auth';
 import type { TrackerConf } from '@server/shared/types';
 import { SettingsService } from '@server/features/settings/settings.service';
 import logger from '@server/lib/logger';
-import {
-  assertNotCloudflareChallenge,
-  CloudflareChallengeError,
-  isCloudflareChallenge,
-} from './utils';
+import { CloudflareChallengeError, isCloudflareChallenge } from './utils';
 import {
   buildCookieHeader,
   fetchWithFlareSolverr,
@@ -97,12 +93,8 @@ export class TrackerDataAdapter {
     cookies: string,
     root: HTMLElement,
   ): Promise<void> {
-    try {
-      assertNotCloudflareChallenge(root);
-    } catch (error) {
-      if (!(error instanceof CloudflareChallengeError)) {
-        throw error;
-      }
+    if (!isCloudflareChallenge(root)) {
+      throw new Error('Server responded with 403');
     }
 
     const settings = await new SettingsService().getSettings();

--- a/server/src/external/adapters/tracker-data/tracker-data.adapter.ts
+++ b/server/src/external/adapters/tracker-data/tracker-data.adapter.ts
@@ -11,11 +11,25 @@ import { customFetch } from '@server/shared/custom-fetch';
 import { TrackerAuth } from './tracker-data.auth';
 import type { TrackerConf } from '@server/shared/types';
 import { SettingsService } from '@server/features/settings/settings.service';
-import { detectCloudflareChallenge } from './utils';
+import logger from '@server/lib/logger';
+import {
+  assertNotCloudflareChallenge,
+  CloudflareChallengeError,
+  isCloudflareChallenge,
+} from './utils';
+import {
+  buildCookieHeader,
+  fetchWithFlareSolverr,
+  type FlareSolverrSolution,
+} from './flaresolverr';
+
+const DEFAULT_FLARESOLVERR_TIMEOUT_SECONDS = 60;
 
 export class TrackerDataAdapter {
   private timeout: number;
   private domRoot: HTMLElement | null = null;
+  private cloudflareCookies: string = '';
+  private cloudflareUserAgent: string = '';
   private rawTitle: string = '';
   private showTitle: string = '';
   private rawUrl: string;
@@ -40,28 +54,105 @@ export class TrackerDataAdapter {
 
   private async fetchDom(url: string = this.rawUrl, cookies: string = '') {
     try {
-      const resp = await customFetch(
-        url,
-        { headers: { Cookie: cookies } },
-        this.timeout
-      );
+      const headers = this.buildRequestHeaders(cookies);
+      const resp = await customFetch(url, { headers }, this.timeout);
       const buffer = await resp.arrayBuffer();
       const detectedEncoding =
         jschardet.detect(Buffer.from(buffer)).encoding || 'utf-8';
       const decodedContent = iconv.decode(
         Buffer.from(buffer),
-        detectedEncoding
+        detectedEncoding,
       );
       const root = parse(decodedContent);
       if (!root) throw new Error('No dom found');
-      this.domRoot = root;
 
-      if (resp.status === 403) {
-        detectCloudflareChallenge(this.domRoot);
+      if (resp.status === 403 || isCloudflareChallenge(root)) {
+        logger.warn('Tracker page requires Cloudflare bypass', {
+          url,
+          tracker: this.tracker,
+          status: resp.status,
+          cloudflareChallenge: isCloudflareChallenge(root),
+          flaresolverrCookiesAvailable: Boolean(this.cloudflareCookies),
+          flaresolverrUserAgentAvailable: Boolean(this.cloudflareUserAgent),
+        });
+        await this.handleForbiddenResponse(url, cookies, root);
+        return;
       }
+
+      this.domRoot = root;
     } catch (e) {
-      throw new Error(`Error fetching ${url}`, { cause: e });
+      logger.error('Tracker page fetch failed', {
+        url,
+        tracker: this.tracker,
+        error: this.describeError(e),
+      });
+      throw new Error(`Error fetching ${url}: ${this.getErrorMessage(e)}`, {
+        cause: e,
+      });
     }
+  }
+
+  private async handleForbiddenResponse(
+    url: string,
+    cookies: string,
+    root: HTMLElement,
+  ): Promise<void> {
+    try {
+      assertNotCloudflareChallenge(root);
+    } catch (error) {
+      if (!(error instanceof CloudflareChallengeError)) {
+        throw error;
+      }
+    }
+
+    const settings = await new SettingsService().getSettings();
+    logger.warn('Cloudflare challenge detected on tracker page', {
+      url,
+      tracker: this.tracker,
+      flaresolverrEnabled: settings?.flaresolverrEnabled ?? false,
+      flaresolverrUrlConfigured: Boolean(settings?.flaresolverrUrl),
+    });
+
+    if (!settings?.flaresolverrEnabled) {
+      throw new CloudflareChallengeError(
+        'Cloudflare Challenge detected, FlareSolverr is disabled',
+      );
+    }
+
+    if (!settings.flaresolverrUrl) {
+      throw new Error('FlareSolverr URL is not configured');
+    }
+
+    let solution: FlareSolverrSolution;
+    try {
+      solution = await fetchWithFlareSolverr({
+        serverUrl: settings.flaresolverrUrl,
+        targetUrl: url,
+        timeout: this.getFlareSolverrTimeout(
+          settings.flaresolverrTimeoutSeconds,
+        ),
+        cookies: this.mergeCookieHeaders(cookies),
+      });
+    } catch (error) {
+      logger.error('FlareSolverr tracker page request failed', {
+        url,
+        tracker: this.tracker,
+        flaresolverrUrl: settings.flaresolverrUrl,
+        error: this.describeError(error),
+      });
+      throw error;
+    }
+
+    this.cloudflareCookies = buildCookieHeader(solution.cookies);
+    this.cloudflareUserAgent = solution.userAgent;
+    this.domRoot = parse(solution.response);
+    logger.info('FlareSolverr tracker page request succeeded', {
+      url,
+      tracker: this.tracker,
+      status: solution.status,
+      cookiesCount: solution.cookies.length,
+      userAgentAvailable: Boolean(solution.userAgent),
+    });
   }
 
   private async getAuth() {
@@ -140,7 +231,7 @@ export class TrackerDataAdapter {
       const url = this.tConf.magnetUrl(
         newUrl.protocol,
         newUrl.host,
-        this.trackerTorrentId
+        this.trackerTorrentId,
       );
       await this.fetchDom(url.href, cookies);
     }
@@ -168,7 +259,7 @@ export class TrackerDataAdapter {
     }
 
     const magnetMatch = magnetElement.textContent.match(
-      this.tConf.magnetRegExp
+      this.tConf.magnetRegExp,
     );
 
     if (!magnetMatch) {
@@ -192,5 +283,64 @@ export class TrackerDataAdapter {
       epAndSeason: this.epAndSeason,
       magnet: this.magnet,
     };
+  }
+
+  private buildRequestHeaders(cookies: string): HeadersInit {
+    const headers: Record<string, string> = {};
+    const mergedCookies = this.mergeCookieHeaders(cookies);
+
+    if (mergedCookies) {
+      headers.Cookie = mergedCookies;
+    }
+
+    if (this.cloudflareUserAgent) {
+      headers['User-Agent'] = this.cloudflareUserAgent;
+    }
+
+    return headers;
+  }
+
+  private mergeCookieHeaders(cookies: string): string {
+    return [cookies, this.cloudflareCookies].filter(Boolean).join('; ');
+  }
+
+  private getFlareSolverrTimeout(timeoutSeconds: number | null): number {
+    const resolvedSeconds =
+      timeoutSeconds ?? DEFAULT_FLARESOLVERR_TIMEOUT_SECONDS;
+    return Math.max(1, resolvedSeconds) * 1000;
+  }
+
+  private describeError(error: unknown): Record<string, unknown> {
+    if (!(error instanceof Error)) {
+      return { message: String(error) };
+    }
+
+    return {
+      name: error.name,
+      message: error.message,
+      cause: this.describeErrorCause(error.cause),
+      stack: error.stack,
+    };
+  }
+
+  private describeErrorCause(cause: unknown): Record<string, unknown> | null {
+    if (!cause) {
+      return null;
+    }
+
+    if (!(cause instanceof Error)) {
+      return { message: String(cause) };
+    }
+
+    return {
+      name: cause.name,
+      message: cause.message,
+      cause: this.describeErrorCause(cause.cause),
+      stack: cause.stack,
+    };
+  }
+
+  private getErrorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
   }
 }

--- a/server/src/external/adapters/tracker-data/utils.ts
+++ b/server/src/external/adapters/tracker-data/utils.ts
@@ -1,11 +1,22 @@
 import type { HTMLElement } from 'node-html-parser';
 
-export function detectCloudflareChallenge(dom: HTMLElement) {
+export class CloudflareChallengeError extends Error {
+  constructor(message = 'Cloudflare Challenge detected') {
+    super(message);
+    this.name = 'CloudflareChallengeError';
+  }
+}
+
+export function isCloudflareChallenge(dom: HTMLElement): boolean {
   const domTitle = dom.querySelector('title')?.textContent;
   const bodyErrorText = dom.querySelector('span.challenge-error-text');
-  if (domTitle?.includes('Just a moment...') || bodyErrorText) {
-    throw new Error('Cloudflare Challenge detected');
-  } else {
-    throw new Error('Server responded with 403');
+  return Boolean(domTitle?.includes('Just a moment...') || bodyErrorText);
+}
+
+export function assertNotCloudflareChallenge(dom: HTMLElement): void {
+  if (isCloudflareChallenge(dom)) {
+    throw new CloudflareChallengeError();
   }
+
+  throw new Error('Server responded with 403');
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -19,6 +19,7 @@ import { deleteFileRoute } from './routes/files.$id.delete';
 import { settingsRoute } from './routes/settings';
 import { jackettSearchRoute } from './routes/jackett.search';
 import { jackettVerifyRoute } from './routes/jackett.verify';
+import { flaresolverrVerifyRoute } from './routes/flaresolverr.verify';
 import { systemExitRoute } from './routes/system.exit';
 import { trackersKinozalVerifyRoute } from './routes/trackers.kinozal.verify';
 import { getUserCount } from './lib/utils';
@@ -50,7 +51,7 @@ if (process.env.NODE_ENV !== 'production') {
       exposeHeaders: ['Content-Length'],
       maxAge: 600,
       credentials: true,
-    })
+    }),
   );
 }
 
@@ -78,6 +79,7 @@ export const routes = app
   .route('/system/exit', systemExitRoute)
   .route('/jackett/search', jackettSearchRoute)
   .route('/jackett/verify', jackettVerifyRoute)
+  .route('/flaresolverr/verify', flaresolverrVerifyRoute)
   .route('/trackers/kinozal/verify', trackersKinozalVerifyRoute)
   .route('/settings', settingsRoute)
   .route('/files/:id/delete', deleteFileRoute)

--- a/server/src/routes/flaresolverr.verify.ts
+++ b/server/src/routes/flaresolverr.verify.ts
@@ -1,0 +1,43 @@
+import { Hono } from 'hono/tiny';
+import type { ApiResponse } from '@shared/types';
+import logger from '@server/lib/logger';
+import { verifyFlareSolverr } from '@server/external/adapters/tracker-data/flaresolverr';
+import { z } from 'zod';
+import { sValidator } from '@hono/standard-validator';
+import { handleStandardValidation } from '@server/lib/validation';
+
+const verifySchema = z.object({
+  flaresolverrUrl: z.url({ message: 'FlareSolverr URL is required' }).trim(),
+  timeoutSeconds: z.number().int().min(1).max(300).default(60),
+});
+
+export const flaresolverrVerifyRoute = new Hono().post(
+  '/',
+  sValidator('json', verifySchema, handleStandardValidation),
+  async (c) => {
+    const { flaresolverrUrl, timeoutSeconds } = c.req.valid('json');
+
+    try {
+      await verifyFlareSolverr({
+        serverUrl: flaresolverrUrl,
+        timeout: timeoutSeconds * 1000,
+      });
+      const successResponse: ApiResponse<null> = {
+        success: true,
+        data: null,
+      };
+      return c.json(successResponse);
+    } catch (error) {
+      logger.error(error);
+      const errorMessage =
+        error instanceof Error
+          ? error.message
+          : 'Unknown error while testing FlareSolverr';
+      const errorResponse: ApiResponse = {
+        success: false,
+        message: `Failed to test FlareSolverr: ${errorMessage}`,
+      };
+      return c.json(errorResponse, 500);
+    }
+  },
+);

--- a/server/src/routes/flaresolverr.verify.ts
+++ b/server/src/routes/flaresolverr.verify.ts
@@ -7,7 +7,10 @@ import { sValidator } from '@hono/standard-validator';
 import { handleStandardValidation } from '@server/lib/validation';
 
 const verifySchema = z.object({
-  flaresolverrUrl: z.url({ message: 'FlareSolverr URL is required' }).trim(),
+  flaresolverrUrl: z
+    .string()
+    .trim()
+    .pipe(z.url({ message: 'FlareSolverr URL is required' })),
   timeoutSeconds: z.number().int().min(1).max(300).default(60),
 });
 

--- a/server/test/download-worker-copy-error.test.ts
+++ b/server/test/download-worker-copy-error.test.ts
@@ -21,10 +21,18 @@ vi.mock('@server/external/adapters/transmission', () => ({
   TransmissionAdapter: class {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     constructor(_: any) {}
-    async add() { /* no-op */ }
-    async status() { return { isCompleted: false, raw: { files: [] }, name: 'Test' }; }
-    async selectEpisodes() { /* no-op */ }
-    async remove() { /* no-op */ }
+    async add() {
+      /* no-op */
+    }
+    async status() {
+      return { isCompleted: false, raw: { files: [] }, name: 'Test' };
+    }
+    async selectEpisodes() {
+      /* no-op */
+    }
+    async remove() {
+      /* no-op */
+    }
   },
 }));
 
@@ -32,13 +40,15 @@ vi.mock('@server/external/adapters/telegram/telegram.adapter', () => ({
   TelegramAdapter: class {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     constructor(_: any) {}
-    sendUpdate(_title: string, _payload: Record<number, string>) { /* no-op */ }
+    sendUpdate(_title: string, _payload: Record<number, string>) {
+      /* no-op */
+    }
   },
 }));
 
 const copyTrackedEpisodes = vi.fn(
   async (_ti: DbTorrentItem, _s: DbUserSettings) =>
-    ({} as Record<number, string>)
+    ({}) as Record<number, string>,
 );
 vi.mock('@server/features/file-management/file-management.service', () => ({
   FileManagementService: class {
@@ -82,7 +92,10 @@ class RepoMock {
     // not needed
   }
 
-  async update(id: number, data: Partial<DbTorrentItem>): Promise<DbTorrentItem | undefined> {
+  async update(
+    id: number,
+    data: Partial<DbTorrentItem>,
+  ): Promise<DbTorrentItem | undefined> {
     this.updates.push({ id, data });
     return undefined;
   }
@@ -121,6 +134,9 @@ describe('DownloadWorker copy failure persists errorMessage', () => {
     jackettUrl: null,
     kinozalUsername: null,
     kinozalPassword: null,
+    flaresolverrEnabled: false,
+    flaresolverrUrl: null,
+    flaresolverrTimeoutSeconds: 60,
   } as const;
 
   beforeEach(() => {
@@ -145,8 +161,12 @@ describe('DownloadWorker copy failure persists errorMessage', () => {
     expect(repo.idled).toEqual([row.id]);
 
     // Assert that errorMessage was persisted
-    const updateWithError = repo.updates.find((u) => typeof u.data.errorMessage === 'string');
+    const updateWithError = repo.updates.find(
+      (u) => typeof u.data.errorMessage === 'string',
+    );
     expect(updateWithError).toBeDefined();
-    expect(String(updateWithError?.data.errorMessage)).toContain('Error processing completed download');
+    expect(String(updateWithError?.data.errorMessage)).toContain(
+      'Error processing completed download',
+    );
   });
 });

--- a/server/test/download-worker-error-message.test.ts
+++ b/server/test/download-worker-error-message.test.ts
@@ -19,7 +19,9 @@ vi.mock('@server/workers/workers.repo', () => ({
 
 // Transmission adapter mock with configurable behavior per test
 const add = vi.fn(async () => undefined);
-const status = vi.fn(async () => ({ isCompleted: false } as { isCompleted: boolean }));
+const status = vi.fn(
+  async () => ({ isCompleted: false }) as { isCompleted: boolean },
+);
 const selectEpisodes = vi.fn(async () => undefined);
 const remove = vi.fn(async () => undefined);
 
@@ -77,7 +79,10 @@ class RepoMock {
     this.completed.push(id);
   }
 
-  async update(id: number, data: Partial<DbTorrentItem>): Promise<DbTorrentItem | undefined> {
+  async update(
+    id: number,
+    data: Partial<DbTorrentItem>,
+  ): Promise<DbTorrentItem | undefined> {
     this.updates.push({ id, data });
     return undefined;
   }
@@ -115,6 +120,9 @@ const settings: DbUserSettings = {
   jackettUrl: null,
   kinozalUsername: null,
   kinozalPassword: null,
+  flaresolverrEnabled: false,
+  flaresolverrUrl: null,
+  flaresolverrTimeoutSeconds: 60,
 };
 
 describe('DownloadWorker errorMessage persistence', () => {
@@ -127,7 +135,10 @@ describe('DownloadWorker errorMessage persistence', () => {
 
   it('persists errorMessage when add() fails on downloadRequested', async () => {
     const { DownloadWorker } = await import('@server/workers/download-worker');
-    const row: DbTorrentItem = { ...baseItem, controlStatus: 'downloadRequested' };
+    const row: DbTorrentItem = {
+      ...baseItem,
+      controlStatus: 'downloadRequested',
+    };
     const repo = new RepoMock([row], settings);
     const worker = new DownloadWorker({ repo: repo as unknown as never });
 
@@ -135,9 +146,13 @@ describe('DownloadWorker errorMessage persistence', () => {
 
     await worker.process();
 
-    const errUpdate = repo.updates.find((u) => typeof u.data.errorMessage === 'string');
+    const errUpdate = repo.updates.find(
+      (u) => typeof u.data.errorMessage === 'string',
+    );
     expect(errUpdate).toBeDefined();
-    expect(String(errUpdate?.data.errorMessage)).toContain('Failed to start downloading');
+    expect(String(errUpdate?.data.errorMessage)).toContain(
+      'Failed to start downloading',
+    );
   });
 
   it('persists errorMessage and marks idle when status() rejects with "Torrent not found"', async () => {
@@ -151,9 +166,13 @@ describe('DownloadWorker errorMessage persistence', () => {
     await worker.process();
 
     expect(repo.idled).toEqual([row.id]);
-    const errUpdate = repo.updates.find((u) => typeof u.data.errorMessage === 'string');
+    const errUpdate = repo.updates.find(
+      (u) => typeof u.data.errorMessage === 'string',
+    );
     expect(errUpdate).toBeDefined();
-    expect(String(errUpdate?.data.errorMessage)).toContain('Failed to check download status');
+    expect(String(errUpdate?.data.errorMessage)).toContain(
+      'Failed to check download status',
+    );
   });
 
   it('persists errorMessage when selectEpisodes() fails during downloading', async () => {
@@ -162,14 +181,20 @@ describe('DownloadWorker errorMessage persistence', () => {
     const repo = new RepoMock([row], settings);
     const worker = new DownloadWorker({ repo: repo as unknown as never });
 
-    status.mockResolvedValueOnce({ isCompleted: false } as { isCompleted: boolean });
+    status.mockResolvedValueOnce({ isCompleted: false } as {
+      isCompleted: boolean;
+    });
     selectEpisodes.mockRejectedValueOnce(new Error('select failed'));
 
     await worker.process();
 
-    const errUpdate = repo.updates.find((u) => typeof u.data.errorMessage === 'string');
+    const errUpdate = repo.updates.find(
+      (u) => typeof u.data.errorMessage === 'string',
+    );
     expect(errUpdate).toBeDefined();
-    expect(String(errUpdate?.data.errorMessage)).toContain('Error selecting episodes');
+    expect(String(errUpdate?.data.errorMessage)).toContain(
+      'Error selecting episodes',
+    );
   });
 
   it('persists errorMessage when checkFiles() encounters unexpected fs error', async () => {
@@ -194,10 +219,14 @@ describe('DownloadWorker errorMessage persistence', () => {
 
     await worker.process();
 
-    const errUpdate = repo.updates.find((u) => typeof u.data.errorMessage === 'string');
+    const errUpdate = repo.updates.find(
+      (u) => typeof u.data.errorMessage === 'string',
+    );
     expect(statSpy).toHaveBeenCalledTimes(1);
     expect(errUpdate).toBeDefined();
-    expect(String(errUpdate?.data.errorMessage)).toContain('Failed to check files');
+    expect(String(errUpdate?.data.errorMessage)).toContain(
+      'Failed to check files',
+    );
 
     if (prev === undefined) delete process.env.HOOP_LAST_SYNC;
     else process.env.HOOP_LAST_SYNC = prev;
@@ -205,14 +234,20 @@ describe('DownloadWorker errorMessage persistence', () => {
 
   it('clears errorMessage when iteration succeeds without errors', async () => {
     const { DownloadWorker } = await import('@server/workers/download-worker');
-    const row: DbTorrentItem = { ...baseItem, controlStatus: 'idle', errorMessage: 'prev' };
+    const row: DbTorrentItem = {
+      ...baseItem,
+      controlStatus: 'idle',
+      errorMessage: 'prev',
+    };
     const repo = new RepoMock([row], settings);
     const worker = new DownloadWorker({ repo: repo as unknown as never });
 
     // Do not set HOOP_LAST_SYNC to skip checkFiles path and keep iteration clean
     await worker.process();
 
-    const clearUpdate = repo.updates.find((u) => Object.prototype.hasOwnProperty.call(u.data, 'errorMessage'));
+    const clearUpdate = repo.updates.find((u) =>
+      Object.prototype.hasOwnProperty.call(u.data, 'errorMessage'),
+    );
     expect(clearUpdate).toBeDefined();
     expect(clearUpdate?.data.errorMessage).toBeNull();
   });

--- a/server/test/download-worker.test.ts
+++ b/server/test/download-worker.test.ts
@@ -50,15 +50,20 @@ const settings: DbUserSettings = {
   jackettUrl: null,
   kinozalUsername: null,
   kinozalPassword: null,
+  flaresolverrEnabled: false,
+  flaresolverrUrl: null,
+  flaresolverrTimeoutSeconds: 60,
 };
 
 // Mocks for collaborators
 const add = vi.fn(async () => undefined);
 import type { NormalizedTorrent } from '@ctrl/shared-torrent';
 const status = vi.fn(
-  async (): Promise<Pick<NormalizedTorrent, 'isCompleted'> & { dateCompleted?: string }> => ({
+  async (): Promise<
+    Pick<NormalizedTorrent, 'isCompleted'> & { dateCompleted?: string }
+  > => ({
     isCompleted: false,
-  })
+  }),
 );
 const selectEpisodes = vi.fn(async () => undefined);
 const remove = vi.fn(async () => undefined);
@@ -98,7 +103,7 @@ vi.mock('@server/external/adapters/telegram/telegram.adapter', () => ({
 
 const copyTrackedEpisodes = vi.fn(
   async (_ti: DbTorrentItem, _s: DbUserSettings) =>
-    ({} as Record<number, string>)
+    ({}) as Record<number, string>,
 );
 vi.mock('@server/features/file-management/file-management.service', () => ({
   FileManagementService: class {
@@ -114,7 +119,7 @@ vi.mock('@server/features/file-management/file-management.service', () => ({
 class RepoMock {
   public findSettings = vi.fn(async () => settings);
   public findAllNeedToControl = vi.fn(
-    async (): Promise<DbTorrentItem[] | null> => []
+    async (): Promise<DbTorrentItem[] | null> => [],
   );
   public markAsCompleted = vi.fn(async (_id: number) => undefined);
   public markAsProcessing = vi.fn(async (_id: number) => undefined);
@@ -304,10 +309,10 @@ describe('DownloadWorker', () => {
 
     const statSpy = vi.spyOn(fs, 'stat');
     statSpy.mockImplementationOnce(
-      async () => ({ isFile: () => true } as never)
+      async () => ({ isFile: () => true }) as never,
     );
     statSpy.mockImplementationOnce(
-      async () => ({ isFile: () => false } as never)
+      async () => ({ isFile: () => false }) as never,
     );
     statSpy.mockImplementationOnce(async () => {
       const err = new Error('missing') as NodeJS.ErrnoException;

--- a/server/test/flaresolverr.test.ts
+++ b/server/test/flaresolverr.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  buildCookieHeader,
+  fetchWithFlareSolverr,
+} from '@server/external/adapters/tracker-data/flaresolverr';
+import { customFetch } from '@server/shared/custom-fetch';
+
+vi.mock('@server/shared/custom-fetch', () => ({
+  customFetch: vi.fn(),
+}));
+
+describe('FlareSolverr client', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('posts request.get payload with parsed cookies', async () => {
+    vi.mocked(customFetch).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          status: 'ok',
+          solution: {
+            status: 200,
+            response: '<html></html>',
+            cookies: [{ name: 'cf_clearance', value: 'token' }],
+            userAgent: 'Mozilla/5.0',
+          },
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      ),
+    );
+
+    const solution = await fetchWithFlareSolverr({
+      serverUrl: 'http://localhost:8191/',
+      targetUrl: 'https://example.com/topic',
+      timeout: 10_000,
+      cookies: 'sid=abc; broken; pref=a=b',
+    });
+    const requestOptions = vi.mocked(customFetch).mock.calls[0]?.[1];
+    const body =
+      typeof requestOptions?.body === 'string'
+        ? (JSON.parse(requestOptions.body) as {
+            cmd: string;
+            url: string;
+            maxTimeout: number;
+            cookies: Array<{ name: string; value: string }>;
+          })
+        : null;
+
+    expect(solution.userAgent).toBe('Mozilla/5.0');
+    expect(vi.mocked(customFetch)).toHaveBeenCalledWith(
+      'http://localhost:8191/v1',
+      expect.objectContaining({ method: 'POST' }),
+      15_000,
+      1,
+    );
+    expect(body).toEqual({
+      cmd: 'request.get',
+      url: 'https://example.com/topic',
+      maxTimeout: 10_000,
+      cookies: [
+        { name: 'sid', value: 'abc' },
+        { name: 'pref', value: 'a=b' },
+      ],
+    });
+  });
+
+  it('throws when FlareSolverr returns a failed status', async () => {
+    vi.mocked(customFetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ status: 'error', message: 'failed' }), {
+        status: 500,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    await expect(
+      fetchWithFlareSolverr({
+        serverUrl: 'http://localhost:8191',
+        targetUrl: 'https://example.com/topic',
+        timeout: 10_000,
+        cookies: '',
+      }),
+    ).rejects.toThrow('failed');
+  });
+
+  it('throws when response body is empty', async () => {
+    vi.mocked(customFetch).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          status: 'ok',
+          solution: {
+            status: 200,
+            response: '',
+            cookies: [],
+            userAgent: 'Mozilla/5.0',
+          },
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      ),
+    );
+
+    await expect(
+      fetchWithFlareSolverr({
+        serverUrl: 'http://localhost:8191',
+        targetUrl: 'https://example.com/topic',
+        timeout: 10_000,
+        cookies: '',
+      }),
+    ).rejects.toThrow('FlareSolverr response body is empty');
+  });
+
+  it('builds cookie header from valid cookies only', () => {
+    expect(
+      buildCookieHeader([
+        { name: 'sid', value: 'abc' },
+        { name: '', value: 'missing-name' },
+        { name: 'empty', value: '' },
+        { name: 'cf_clearance', value: 'token' },
+      ]),
+    ).toBe('sid=abc; cf_clearance=token');
+  });
+});

--- a/server/test/flaresolverr.test.ts
+++ b/server/test/flaresolverr.test.ts
@@ -34,7 +34,7 @@ describe('FlareSolverr client', () => {
     );
 
     const solution = await fetchWithFlareSolverr({
-      serverUrl: 'http://localhost:8191/',
+      serverUrl: 'http://localhost:8191/proxy/',
       targetUrl: 'https://example.com/topic',
       timeout: 10_000,
       cookies: 'sid=abc; broken; pref=a=b',
@@ -52,7 +52,7 @@ describe('FlareSolverr client', () => {
 
     expect(solution.userAgent).toBe('Mozilla/5.0');
     expect(vi.mocked(customFetch)).toHaveBeenCalledWith(
-      'http://localhost:8191/v1',
+      'http://localhost:8191/proxy/v1',
       expect.objectContaining({ method: 'POST' }),
       15_000,
       1,

--- a/server/test/routes/flaresolverr-route.test.ts
+++ b/server/test/routes/flaresolverr-route.test.ts
@@ -34,7 +34,7 @@ describe('flaresolverrVerifyRoute', () => {
     const response = await flaresolverrVerifyRoute.request('/', {
       method: 'POST',
       body: JSON.stringify({
-        flaresolverrUrl: 'http://localhost:8191',
+        flaresolverrUrl: ' http://localhost:8191/proxy ',
         timeoutSeconds: 60,
       }),
       headers: {
@@ -52,7 +52,7 @@ describe('flaresolverrVerifyRoute', () => {
     expect(body.success).toBe(true);
     expect(requestBody).toEqual({ cmd: 'sessions.list' });
     expect(vi.mocked(customFetch)).toHaveBeenCalledWith(
-      'http://localhost:8191/v1',
+      'http://localhost:8191/proxy/v1',
       expect.objectContaining({ method: 'POST' }),
       60_000,
       1,

--- a/server/test/routes/flaresolverr-route.test.ts
+++ b/server/test/routes/flaresolverr-route.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { flaresolverrVerifyRoute } from '@server/routes/flaresolverr.verify';
+import { customFetch } from '@server/shared/custom-fetch';
+
+type ApiResponse<T> = {
+  success: boolean;
+  message?: string;
+  data?: T;
+};
+
+vi.mock('@server/shared/custom-fetch', () => ({
+  customFetch: vi.fn(),
+}));
+
+vi.mock('@server/lib/logger', () => ({
+  default: {
+    error: vi.fn(),
+  },
+}));
+
+describe('flaresolverrVerifyRoute', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('verifies FlareSolverr availability', async () => {
+    vi.mocked(customFetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ status: 'ok', sessions: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    const response = await flaresolverrVerifyRoute.request('/', {
+      method: 'POST',
+      body: JSON.stringify({
+        flaresolverrUrl: 'http://localhost:8191',
+        timeoutSeconds: 60,
+      }),
+      headers: {
+        'content-type': 'application/json',
+      },
+    });
+    const body = (await response.json()) as ApiResponse<null>;
+    const requestOptions = vi.mocked(customFetch).mock.calls[0]?.[1];
+    const requestBody =
+      typeof requestOptions?.body === 'string'
+        ? (JSON.parse(requestOptions.body) as { cmd: string })
+        : null;
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(requestBody).toEqual({ cmd: 'sessions.list' });
+    expect(vi.mocked(customFetch)).toHaveBeenCalledWith(
+      'http://localhost:8191/v1',
+      expect.objectContaining({ method: 'POST' }),
+      60_000,
+      1,
+    );
+  });
+
+  it('returns an error when FlareSolverr is unavailable', async () => {
+    vi.mocked(customFetch).mockRejectedValueOnce(new Error('offline'));
+
+    const response = await flaresolverrVerifyRoute.request('/', {
+      method: 'POST',
+      body: JSON.stringify({
+        flaresolverrUrl: 'http://localhost:8191',
+        timeoutSeconds: 5,
+      }),
+      headers: {
+        'content-type': 'application/json',
+      },
+    });
+    const body = (await response.json()) as ApiResponse<null>;
+
+    expect(response.status).toBe(500);
+    expect(body.success).toBe(false);
+    expect(body.message).toContain('offline');
+  });
+});

--- a/server/test/routes/settings-route.test.ts
+++ b/server/test/routes/settings-route.test.ts
@@ -12,6 +12,9 @@ type SettingsPayload = {
   jackettUrl: string | null;
   kinozalUsername: string | null;
   kinozalPassword: string | null;
+  flaresolverrEnabled: boolean | null;
+  flaresolverrUrl: string | null;
+  flaresolverrTimeoutSeconds: number;
 };
 
 interface SettingsRequestPayload extends SettingsPayload {
@@ -26,9 +29,8 @@ type SettingsResponse<T> = {
 
 const { getSettingsMock, upsertMock } = vi.hoisted(() => {
   const getSettingsMock = vi.fn<() => Promise<SettingsRequestPayload | null>>();
-  const upsertMock = vi.fn<
-    (payload: SettingsPayload) => Promise<SettingsPayload | null>
-  >();
+  const upsertMock =
+    vi.fn<(payload: SettingsPayload) => Promise<SettingsPayload | null>>();
   return { getSettingsMock, upsertMock } as const;
 });
 
@@ -63,6 +65,9 @@ const sampleSettings: SettingsPayload = {
   jackettUrl: null,
   kinozalUsername: null,
   kinozalPassword: null,
+  flaresolverrEnabled: false,
+  flaresolverrUrl: null,
+  flaresolverrTimeoutSeconds: 60,
 };
 
 beforeEach(() => {
@@ -75,7 +80,8 @@ describe('settingsRoute', () => {
     getSettingsMock.mockResolvedValueOnce({ id: 1, ...sampleSettings });
 
     const response = await settingsRoute.request('/');
-    const body = (await response.json()) as SettingsResponse<SettingsRequestPayload | null>;
+    const body =
+      (await response.json()) as SettingsResponse<SettingsRequestPayload | null>;
 
     expect(response.status).toBe(200);
     expect(body.success).toBe(true);
@@ -112,6 +118,9 @@ describe('settingsRoute', () => {
       jackettUrl: payload.jackettUrl,
       kinozalUsername: payload.kinozalUsername,
       kinozalPassword: payload.kinozalPassword,
+      flaresolverrEnabled: payload.flaresolverrEnabled,
+      flaresolverrUrl: payload.flaresolverrUrl,
+      flaresolverrTimeoutSeconds: payload.flaresolverrTimeoutSeconds,
     };
 
     upsertMock.mockResolvedValueOnce(expectedPayload);
@@ -124,7 +133,8 @@ describe('settingsRoute', () => {
       },
     });
 
-    const body = (await response.json()) as SettingsResponse<SettingsPayload | null>;
+    const body =
+      (await response.json()) as SettingsResponse<SettingsPayload | null>;
 
     expect(response.status).toBe(200);
     expect(upsertMock).toHaveBeenCalledWith(expectedPayload);

--- a/server/test/settings.repo.test.ts
+++ b/server/test/settings.repo.test.ts
@@ -50,9 +50,7 @@ const repoDb = {
 } as unknown as BunSQLiteDatabase & { $client: Database };
 const repo = new SettingsRepo(repoDb);
 
-function makeSettings(
-  override: Partial<DbUserSettings> = {}
-): DbUserSettings {
+function makeSettings(override: Partial<DbUserSettings> = {}): DbUserSettings {
   return {
     id: 1,
     telegramId: 123,
@@ -65,6 +63,9 @@ function makeSettings(
     jackettUrl: null,
     kinozalUsername: null,
     kinozalPassword: null,
+    flaresolverrEnabled: false,
+    flaresolverrUrl: null,
+    flaresolverrTimeoutSeconds: 60,
     ...override,
   } satisfies DbUserSettings;
 }
@@ -109,6 +110,9 @@ describe('SettingsRepo (mocked database)', () => {
       jackettUrl: 'https://jackett.dev',
       kinozalUsername: 'user',
       kinozalPassword: 'pass',
+      flaresolverrEnabled: true,
+      flaresolverrUrl: 'http://localhost:8191',
+      flaresolverrTimeoutSeconds: 90,
     };
 
     const result = await repo.upsert(payload);

--- a/server/test/settings.service.test.ts
+++ b/server/test/settings.service.test.ts
@@ -24,15 +24,17 @@ const database = {
     })),
   })),
   insert: vi.fn(() => ({
-    values: vi.fn((values: Omit<DbUserSettingsInsert, 'id'> & { id?: number }) => {
-      const { id: _id, ...rest } = values;
-      lastUpsertValues = rest;
-      return {
-        returning: vi.fn(() => ({
-          onConflictDoUpdate: vi.fn(async () => upsertQueue.shift() ?? []),
-        })),
-      };
-    }),
+    values: vi.fn(
+      (values: Omit<DbUserSettingsInsert, 'id'> & { id?: number }) => {
+        const { id: _id, ...rest } = values;
+        lastUpsertValues = rest;
+        return {
+          returning: vi.fn(() => ({
+            onConflictDoUpdate: vi.fn(async () => upsertQueue.shift() ?? []),
+          })),
+        };
+      },
+    ),
   })),
   update: vi.fn(() => ({
     set: vi.fn((values: Partial<Omit<DbUserSettingsInsert, 'id'>>) => {
@@ -52,7 +54,7 @@ const repo = new SettingsRepo({
 } as never);
 
 function makeSettingsRow(
-  override: Partial<DbUserSettings> = {}
+  override: Partial<DbUserSettings> = {},
 ): DbUserSettings {
   return {
     id: 1,
@@ -66,6 +68,9 @@ function makeSettingsRow(
     jackettUrl: null,
     kinozalUsername: null,
     kinozalPassword: null,
+    flaresolverrEnabled: false,
+    flaresolverrUrl: null,
+    flaresolverrTimeoutSeconds: 60,
     ...override,
   } satisfies DbUserSettings;
 }
@@ -94,6 +99,9 @@ describe('SettingsRepo (mocked database)', () => {
       jackettUrl: null,
       kinozalUsername: null,
       kinozalPassword: null,
+      flaresolverrEnabled: false,
+      flaresolverrUrl: null,
+      flaresolverrTimeoutSeconds: 60,
     };
 
     const inserted = await repo.upsert(payload);
@@ -125,11 +133,19 @@ describe('SettingsRepo (mocked database)', () => {
 describe('SettingsService', () => {
   it('throws when updating without data', async () => {
     class RepoMock extends SettingsRepo {
-      public findSettings = vi.fn(async (): Promise<DbUserSettings | null> => null);
-      public upsert = vi
-        .fn(async (_payload: Omit<DbUserSettingsInsert, 'id'>): Promise<DbUserSettings | null> => null);
-      public update = vi
-        .fn(async (_payload: Partial<Omit<DbUserSettingsInsert, 'id'>>): Promise<DbUserSettings | null> => null);
+      public findSettings = vi.fn(
+        async (): Promise<DbUserSettings | null> => null,
+      );
+      public upsert = vi.fn(
+        async (
+          _payload: Omit<DbUserSettingsInsert, 'id'>,
+        ): Promise<DbUserSettings | null> => null,
+      );
+      public update = vi.fn(
+        async (
+          _payload: Partial<Omit<DbUserSettingsInsert, 'id'>>,
+        ): Promise<DbUserSettings | null> => null,
+      );
     }
 
     const service = new SettingsService({ repo: new RepoMock({} as never) });
@@ -154,38 +170,28 @@ describe('SettingsService', () => {
     const fullData = data as Required<Omit<DbUserSettingsInsert, 'id'>>;
 
     class RepoMock2 extends SettingsRepo {
-      public findSettings = vi.fn(async (): Promise<DbUserSettings | null> => ({
-        id: 1,
-        telegramId: fullData.telegramId,
-        botToken: fullData.botToken,
-        downloadDir: fullData.downloadDir,
-        mediaDir: fullData.mediaDir,
-        deleteAfterDownload: fullData.deleteAfterDownload,
-        syncInterval: fullData.syncInterval,
-        jackettApiKey: fullData.jackettApiKey,
-        jackettUrl: fullData.jackettUrl,
-        kinozalUsername: fullData.kinozalUsername,
-        kinozalPassword: fullData.kinozalPassword,
-      } satisfies DbUserSettings));
-      public upsert = vi.fn(
-        async (payload: Omit<DbUserSettingsInsert, 'id'>): Promise<DbUserSettings | null> => ({
-          id: 1,
-          telegramId: payload.telegramId ?? fullData.telegramId,
-          botToken: payload.botToken ?? fullData.botToken,
-          downloadDir: payload.downloadDir ?? fullData.downloadDir,
-          mediaDir: payload.mediaDir ?? fullData.mediaDir,
-          deleteAfterDownload:
-            payload.deleteAfterDownload ?? fullData.deleteAfterDownload,
-          syncInterval: payload.syncInterval ?? fullData.syncInterval,
-          jackettApiKey: payload.jackettApiKey ?? fullData.jackettApiKey,
-          jackettUrl: payload.jackettUrl ?? fullData.jackettUrl,
-          kinozalUsername: payload.kinozalUsername ?? fullData.kinozalUsername,
-          kinozalPassword: payload.kinozalPassword ?? fullData.kinozalPassword,
-        } satisfies DbUserSettings)
+      public findSettings = vi.fn(
+        async (): Promise<DbUserSettings | null> =>
+          ({
+            id: 1,
+            telegramId: fullData.telegramId,
+            botToken: fullData.botToken,
+            downloadDir: fullData.downloadDir,
+            mediaDir: fullData.mediaDir,
+            deleteAfterDownload: fullData.deleteAfterDownload,
+            syncInterval: fullData.syncInterval,
+            jackettApiKey: fullData.jackettApiKey,
+            jackettUrl: fullData.jackettUrl,
+            kinozalUsername: fullData.kinozalUsername,
+            kinozalPassword: fullData.kinozalPassword,
+            flaresolverrEnabled: fullData.flaresolverrEnabled,
+            flaresolverrUrl: fullData.flaresolverrUrl,
+            flaresolverrTimeoutSeconds: fullData.flaresolverrTimeoutSeconds,
+          }) satisfies DbUserSettings,
       );
-      public update = vi.fn(
+      public upsert = vi.fn(
         async (
-          payload: Partial<Omit<DbUserSettingsInsert, 'id'>>
+          payload: Omit<DbUserSettingsInsert, 'id'>,
         ): Promise<DbUserSettings | null> =>
           ({
             id: 1,
@@ -202,7 +208,42 @@ describe('SettingsService', () => {
               payload.kinozalUsername ?? fullData.kinozalUsername,
             kinozalPassword:
               payload.kinozalPassword ?? fullData.kinozalPassword,
-          } satisfies DbUserSettings)
+            flaresolverrEnabled:
+              payload.flaresolverrEnabled ?? fullData.flaresolverrEnabled,
+            flaresolverrUrl:
+              payload.flaresolverrUrl ?? fullData.flaresolverrUrl,
+            flaresolverrTimeoutSeconds:
+              payload.flaresolverrTimeoutSeconds ??
+              fullData.flaresolverrTimeoutSeconds,
+          }) satisfies DbUserSettings,
+      );
+      public update = vi.fn(
+        async (
+          payload: Partial<Omit<DbUserSettingsInsert, 'id'>>,
+        ): Promise<DbUserSettings | null> =>
+          ({
+            id: 1,
+            telegramId: payload.telegramId ?? fullData.telegramId,
+            botToken: payload.botToken ?? fullData.botToken,
+            downloadDir: payload.downloadDir ?? fullData.downloadDir,
+            mediaDir: payload.mediaDir ?? fullData.mediaDir,
+            deleteAfterDownload:
+              payload.deleteAfterDownload ?? fullData.deleteAfterDownload,
+            syncInterval: payload.syncInterval ?? fullData.syncInterval,
+            jackettApiKey: payload.jackettApiKey ?? fullData.jackettApiKey,
+            jackettUrl: payload.jackettUrl ?? fullData.jackettUrl,
+            kinozalUsername:
+              payload.kinozalUsername ?? fullData.kinozalUsername,
+            kinozalPassword:
+              payload.kinozalPassword ?? fullData.kinozalPassword,
+            flaresolverrEnabled:
+              payload.flaresolverrEnabled ?? fullData.flaresolverrEnabled,
+            flaresolverrUrl:
+              payload.flaresolverrUrl ?? fullData.flaresolverrUrl,
+            flaresolverrTimeoutSeconds:
+              payload.flaresolverrTimeoutSeconds ??
+              fullData.flaresolverrTimeoutSeconds,
+          }) satisfies DbUserSettings,
       );
     }
 
@@ -213,14 +254,20 @@ describe('SettingsService', () => {
 
     const inserted = await service.upsert();
     expect(inserted?.id).toBe(1);
-    expect((service as unknown as { repo: RepoMock2 }).repo.upsert).toHaveBeenCalledWith(data);
+    expect(
+      (service as unknown as { repo: RepoMock2 }).repo.upsert,
+    ).toHaveBeenCalledWith(data);
 
     const fetched = await service.getSettings();
     expect(fetched?.id).toBe(1);
-    expect((service as unknown as { repo: RepoMock2 }).repo.findSettings).toHaveBeenCalledTimes(1);
+    expect(
+      (service as unknown as { repo: RepoMock2 }).repo.findSettings,
+    ).toHaveBeenCalledTimes(1);
 
     const updated = await service.update();
     expect(updated?.id).toBe(1);
-    expect((service as unknown as { repo: RepoMock2 }).repo.update).toHaveBeenCalledWith(data);
+    expect(
+      (service as unknown as { repo: RepoMock2 }).repo.update,
+    ).toHaveBeenCalledWith(data);
   });
 });

--- a/server/test/telegram-adapter.test.ts
+++ b/server/test/telegram-adapter.test.ts
@@ -15,6 +15,9 @@ const baseSettings: DbUserSettings = {
   jackettUrl: null,
   kinozalUsername: null,
   kinozalPassword: null,
+  flaresolverrEnabled: false,
+  flaresolverrUrl: null,
+  flaresolverrTimeoutSeconds: 60,
 };
 
 const okResponsePayload = {
@@ -38,13 +41,13 @@ afterEach(() => {
 describe('TelegramAdapter', () => {
   it('throws when bot token is missing', () => {
     expect(
-      () => new TelegramAdapter({ ...baseSettings, botToken: null })
+      () => new TelegramAdapter({ ...baseSettings, botToken: null }),
     ).toThrow('TELEGRAM_BOT_TOKEN is not set');
   });
 
   it('throws when chat id is missing', () => {
     expect(
-      () => new TelegramAdapter({ ...baseSettings, telegramId: null })
+      () => new TelegramAdapter({ ...baseSettings, telegramId: null }),
     ).toThrow('TELEGRAM_CHAT_ID is not set');
   });
 
@@ -53,7 +56,7 @@ describe('TelegramAdapter', () => {
       new Response(JSON.stringify(okResponsePayload), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
-      })
+      }),
     );
     vi.stubGlobal('fetch', fetchMock);
 
@@ -74,7 +77,7 @@ describe('TelegramAdapter', () => {
     const payload = JSON.parse(init?.body as string);
     expect(payload.chat_id).toBe('123456');
     expect(payload.text).toBe(
-      'Downloaded "Some Show" episodes:\n - S01E01\n - S01E02\n'
+      'Downloaded "Some Show" episodes:\n - S01E01\n - S01E02\n',
     );
 
     expect(result).toEqual(okResponsePayload.result);
@@ -89,7 +92,7 @@ describe('TelegramAdapter', () => {
     const adapter = new TelegramAdapter(baseSettings);
 
     await expect(adapter.sendUpdate('Show', {})).rejects.toThrow(
-      'Telegram API sendMessage failed: 502 gateway fail'
+      'Telegram API sendMessage failed: 502 gateway fail',
     );
   });
 
@@ -102,7 +105,7 @@ describe('TelegramAdapter', () => {
     const adapter = new TelegramAdapter(baseSettings);
 
     await expect(adapter.sendUpdate('Show', {})).rejects.toThrow(
-      'Telegram API sendMessage returned invalid JSON'
+      'Telegram API sendMessage returned invalid JSON',
     );
   });
 
@@ -114,15 +117,15 @@ describe('TelegramAdapter', () => {
           error_code: 400,
           description: 'Bad request',
         }),
-        { status: 200, headers: { 'Content-Type': 'application/json' } }
-      )
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
     );
     vi.stubGlobal('fetch', fetchMock);
 
     const adapter = new TelegramAdapter(baseSettings);
 
     await expect(adapter.sendUpdate('Show', {})).rejects.toThrow(
-      'Telegram API sendMessage error: 400 Bad request'
+      'Telegram API sendMessage error: 400 Bad request',
     );
   });
 });

--- a/server/test/tracker-data.test.ts
+++ b/server/test/tracker-data.test.ts
@@ -1,55 +1,73 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // Stabilize encoding detection
-vi.mock("jschardet", () => ({
-  default: { detect: () => ({ encoding: "utf-8" }) },
+vi.mock('jschardet', () => ({
+  default: { detect: () => ({ encoding: 'utf-8' }) },
+}));
+
+vi.mock('@server/lib/logger', () => ({
+  default: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+const { settingsMock } = vi.hoisted(() => ({
+  settingsMock: {
+    id: 1,
+    telegramId: null,
+    botToken: null,
+    downloadDir: null,
+    mediaDir: null,
+    deleteAfterDownload: false,
+    syncInterval: 30,
+    jackettApiKey: null,
+    jackettUrl: null,
+    kinozalUsername: null,
+    kinozalPassword: null,
+    flaresolverrEnabled: false as boolean,
+    flaresolverrUrl: null as string | null,
+    flaresolverrTimeoutSeconds: 60,
+  },
 }));
 
 // Mock SettingsService to avoid bun:sqlite import chain
-vi.mock("@server/features/settings/settings.service", () => ({
+vi.mock('@server/features/settings/settings.service', () => ({
   SettingsService: class {
     async getSettings() {
-      return Promise.resolve({
-        id: 1,
-        telegramId: null,
-        botToken: null,
-        downloadDir: null,
-        mediaDir: null,
-        deleteAfterDownload: false,
-        syncInterval: 30,
-        jackettApiKey: null,
-        jackettUrl: null,
-        kinozalUsername: null,
-        kinozalPassword: null,
-      });
+      return Promise.resolve({ ...settingsMock });
     }
   },
 }));
 
 // Mock network calls
-vi.mock("@server/shared/custom-fetch", () => ({
+vi.mock('@server/shared/custom-fetch', () => ({
   customFetch: vi.fn(),
 }));
 
-import { TrackerDataAdapter } from "@server/external/adapters/tracker-data";
-import { customFetch } from "@server/shared/custom-fetch";
-import { TrackerAuth } from "@server/external/adapters/tracker-data/tracker-data.auth";
+import { TrackerDataAdapter } from '@server/external/adapters/tracker-data';
+import { customFetch } from '@server/shared/custom-fetch';
+import { TrackerAuth } from '@server/external/adapters/tracker-data/tracker-data.auth';
 
 const toResponse = (html: string): Response =>
   new Response(html, {
-    headers: { "content-type": "text/html; charset=utf-8" },
+    headers: { 'content-type': 'text/html; charset=utf-8' },
   });
 
-describe("TrackerData.collect", () => {
+describe('TrackerData.collect', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    settingsMock.flaresolverrEnabled = false;
+    settingsMock.flaresolverrUrl = null;
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it("throws with Cloudflare Challenge cause when 403 page indicates challenge", async () => {
+  it('throws with Cloudflare Challenge cause when 403 page indicates challenge', async () => {
     const cfHtml = `
       <html>
         <head><title>Just a moment...</title></head>
@@ -59,26 +77,146 @@ describe("TrackerData.collect", () => {
     vi.mocked(customFetch).mockResolvedValueOnce(
       new Response(cfHtml, {
         status: 403,
-        headers: { "content-type": "text/html; charset=utf-8" },
+        headers: { 'content-type': 'text/html; charset=utf-8' },
       }),
     );
 
-    const url = "https://rutracker.org/forum/viewtopic.php?t=999";
-    const td = new TrackerDataAdapter({ url, tracker: "rutracker" });
+    const url = 'https://rutracker.org/forum/viewtopic.php?t=999';
+    const td = new TrackerDataAdapter({ url, tracker: 'rutracker' });
 
     try {
       await td.collect();
-      throw new Error("should throw");
+      throw new Error('should throw');
     } catch (err) {
       const e = err as Error & { cause?: unknown };
       expect(e.message).toMatch(/^Error fetching/);
       const causeMsg =
         e.cause instanceof Error ? e.cause.message : String(e.cause);
-      expect(String(causeMsg)).toContain("Cloudflare Challenge detected");
+      expect(String(causeMsg)).toContain('Cloudflare Challenge detected');
     }
   });
 
-  it("throws with 403 cause when 403 page does not indicate challenge", async () => {
+  it('uses FlareSolverr when Cloudflare Challenge is detected and bypass is enabled', async () => {
+    settingsMock.flaresolverrEnabled = true;
+    settingsMock.flaresolverrUrl = 'http://localhost:8191';
+
+    const cfHtml = `
+      <html>
+        <head><title>Just a moment...</title></head>
+        <body><span class="challenge-error-text">Checking your browser...</span></body>
+      </html>`;
+    const solvedHtml = `
+      <html>
+        <body>
+          <div class="maintitle">
+            Название шоу / extra (Сезон: 1 / Серии: 2 из 2)
+          </div>
+          <div class="attach_link"><a href="magnet:?xt=urn:btih:ABCDEF1234567890">magnet</a></div>
+        </body>
+      </html>`;
+
+    const mockedFetch = vi.mocked(customFetch);
+    mockedFetch
+      .mockResolvedValueOnce(
+        new Response(cfHtml, {
+          status: 403,
+          headers: { 'content-type': 'text/html; charset=utf-8' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            status: 'ok',
+            solution: {
+              status: 200,
+              response: solvedHtml,
+              cookies: [{ name: 'cf_clearance', value: 'token' }],
+              userAgent: 'Mozilla/5.0 FlareSolverr',
+            },
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          },
+        ),
+      );
+
+    const url = 'https://rutracker.org/forum/viewtopic.php?t=1200';
+    const td = new TrackerDataAdapter({ url, tracker: 'rutracker' });
+    const result = await td.collect();
+    const flaresolverrOptions = mockedFetch.mock.calls[1]?.[1];
+    const flaresolverrBody =
+      typeof flaresolverrOptions?.body === 'string'
+        ? (JSON.parse(flaresolverrOptions.body) as { maxTimeout: number })
+        : null;
+
+    expect(result.torrentId).toBe('1200');
+    expect(result.magnet).toBe('magnet:?xt=urn:btih:ABCDEF1234567890');
+    expect(flaresolverrBody?.maxTimeout).toBe(60_000);
+    expect(mockedFetch).toHaveBeenNthCalledWith(
+      2,
+      'http://localhost:8191/v1',
+      expect.objectContaining({
+        method: 'POST',
+      }),
+      65_000,
+      1,
+    );
+  });
+
+  it('uses FlareSolverr when Cloudflare Challenge is returned with non-403 status', async () => {
+    settingsMock.flaresolverrEnabled = true;
+    settingsMock.flaresolverrUrl = 'http://localhost:8191';
+
+    const cfHtml = `
+      <html>
+        <head><title>Just a moment...</title></head>
+        <body><span class="challenge-error-text">Checking your browser...</span></body>
+      </html>`;
+    const solvedHtml = `
+      <html>
+        <body>
+          <div class="maintitle">
+            Название шоу / extra (Сезон: 1 / Серии: 2 из 2)
+          </div>
+          <div class="gensmall"><a href="magnet:?xt=urn:btih:ABCDEF1234567890">magnet</a></div>
+        </body>
+      </html>`;
+
+    vi.mocked(customFetch)
+      .mockResolvedValueOnce(
+        new Response(cfHtml, {
+          status: 503,
+          headers: { 'content-type': 'text/html; charset=utf-8' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            status: 'ok',
+            solution: {
+              status: 200,
+              response: solvedHtml,
+              cookies: [{ name: 'cf_clearance', value: 'token' }],
+              userAgent: 'Mozilla/5.0 FlareSolverr',
+            },
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          },
+        ),
+      );
+
+    const url = 'https://nnmclub.to/forum/viewtopic.php?t=1734651';
+    const td = new TrackerDataAdapter({ url, tracker: 'nnmClub' });
+    const result = await td.collect();
+
+    expect(result.torrentId).toBe('1734651');
+    expect(result.magnet).toBe('magnet:?xt=urn:btih:ABCDEF1234567890');
+  });
+
+  it('throws with 403 cause when 403 page does not indicate challenge', async () => {
     const plain403 = `
       <html>
         <head><title>Forbidden</title></head>
@@ -88,16 +226,16 @@ describe("TrackerData.collect", () => {
     vi.mocked(customFetch).mockResolvedValueOnce(
       new Response(plain403, {
         status: 403,
-        headers: { "content-type": "text/html; charset=utf-8" },
+        headers: { 'content-type': 'text/html; charset=utf-8' },
       }),
     );
 
-    const url = "https://rutracker.org/forum/viewtopic.php?t=1000";
-    const td = new TrackerDataAdapter({ url, tracker: "rutracker" });
+    const url = 'https://rutracker.org/forum/viewtopic.php?t=1000';
+    const td = new TrackerDataAdapter({ url, tracker: 'rutracker' });
 
     try {
       await td.collect();
-      throw new Error("should throw");
+      throw new Error('should throw');
     } catch (err) {
       const e = err as Error & { cause?: unknown };
       expect(e.message).toMatch(/^Error fetching/);
@@ -107,7 +245,7 @@ describe("TrackerData.collect", () => {
     }
   });
 
-  it("rutracker: parses data from anchor href (no auth)", async () => {
+  it('rutracker: parses data from anchor href (no auth)', async () => {
     const topicHtml = `
       <html>
         <body>
@@ -121,23 +259,23 @@ describe("TrackerData.collect", () => {
     const mockedFetch = vi.mocked(customFetch);
     mockedFetch.mockResolvedValueOnce(toResponse(topicHtml));
 
-    const url = "https://rutracker.org/forum/viewtopic.php?t=123";
-    const td = new TrackerDataAdapter({ url, tracker: "rutracker" });
+    const url = 'https://rutracker.org/forum/viewtopic.php?t=123';
+    const td = new TrackerDataAdapter({ url, tracker: 'rutracker' });
     const result = await td.collect();
 
-    expect(result.torrentId).toBe("123");
-    expect(result.rawTitle).toContain("Название шоу");
-    expect(result.showTitle).toBe("Название шоу");
+    expect(result.torrentId).toBe('123');
+    expect(result.rawTitle).toContain('Название шоу');
+    expect(result.showTitle).toBe('Название шоу');
     expect(result.epAndSeason).toEqual({
       season: 2,
       startEp: 3,
       endEp: 5,
       totalEp: 10,
     });
-    expect(result.magnet).toBe("magnet:?xt=urn:btih:ABCDEF1234567890");
+    expect(result.magnet).toBe('magnet:?xt=urn:btih:ABCDEF1234567890');
   });
 
-  it("rutracker: parses episodes label without season colon", async () => {
+  it('rutracker: parses episodes label without season colon', async () => {
     const topicHtml = `
       <html>
         <body>
@@ -151,11 +289,11 @@ describe("TrackerData.collect", () => {
     const mockedFetch = vi.mocked(customFetch);
     mockedFetch.mockResolvedValueOnce(toResponse(topicHtml));
 
-    const url = "https://rutracker.org/forum/viewtopic.php?t=124";
-    const td = new TrackerDataAdapter({ url, tracker: "rutracker" });
+    const url = 'https://rutracker.org/forum/viewtopic.php?t=124';
+    const td = new TrackerDataAdapter({ url, tracker: 'rutracker' });
     const result = await td.collect();
 
-    expect(result.showTitle).toBe("Ферма Кларксона");
+    expect(result.showTitle).toBe('Ферма Кларксона');
     expect(result.epAndSeason).toEqual({
       season: 5,
       startEp: 1,
@@ -164,7 +302,7 @@ describe("TrackerData.collect", () => {
     });
   });
 
-  it("kinozal: magnet on separate page, cookies via auth", async () => {
+  it('kinozal: magnet on separate page, cookies via auth', async () => {
     const pageHtml = `
       <html>
         <body>
@@ -186,29 +324,29 @@ describe("TrackerData.collect", () => {
 
     class MockTrackerAuth extends TrackerAuth {
       public async getCookies(): Promise<string> {
-        return "sid=abc";
+        return 'sid=abc';
       }
     }
 
-    const url = "https://kinozal.tv/details.php?id=777";
+    const url = 'https://kinozal.tv/details.php?id=777';
     const trackerAuth = new MockTrackerAuth({
-      login: "login",
-      password: "pass",
-      baseUrl: "https://kinozal.tv",
-      tracker: "kinozal",
+      login: 'login',
+      password: 'pass',
+      baseUrl: 'https://kinozal.tv',
+      tracker: 'kinozal',
     });
 
     const td = new TrackerDataAdapter({
       url,
-      tracker: "kinozal",
+      tracker: 'kinozal',
       trackerAuth,
     });
     const result = await td.collect();
 
-    expect(result.torrentId).toBe("777");
-    expect(result.rawTitle).toContain("Сериал / Название сериала");
+    expect(result.torrentId).toBe('777');
+    expect(result.rawTitle).toContain('Сериал / Название сериала');
     expect(result.showTitle).toBe(
-      "Название сериала (1 сезон: 1-10 серии из 10)",
+      'Название сериала (1 сезон: 1-10 серии из 10)',
     );
     expect(result.epAndSeason).toEqual({
       season: 1,
@@ -216,10 +354,10 @@ describe("TrackerData.collect", () => {
       endEp: 10,
       totalEp: 10,
     });
-    expect(result.magnet).toBe("DEADBEEF1234");
+    expect(result.magnet).toBe('DEADBEEF1234');
   });
 
-  it("kinozal: parses single episode with plural word", async () => {
+  it('kinozal: parses single episode with plural word', async () => {
     const pageHtml = `
       <html>
         <body>
@@ -241,38 +379,38 @@ describe("TrackerData.collect", () => {
 
     class MockTrackerAuth extends TrackerAuth {
       public async getCookies(): Promise<string> {
-        return "sid=abc";
+        return 'sid=abc';
       }
     }
 
-    const url = "https://kinozal.tv/details.php?id=778";
+    const url = 'https://kinozal.tv/details.php?id=778';
     const trackerAuth = new MockTrackerAuth({
-      login: "login",
-      password: "pass",
-      baseUrl: "https://kinozal.tv",
-      tracker: "kinozal",
+      login: 'login',
+      password: 'pass',
+      baseUrl: 'https://kinozal.tv',
+      tracker: 'kinozal',
     });
 
     const td = new TrackerDataAdapter({
       url,
-      tracker: "kinozal",
+      tracker: 'kinozal',
       trackerAuth,
     });
     const result = await td.collect();
 
-    expect(result.torrentId).toBe("778");
-    expect(result.rawTitle).toContain("Сериал / Название сериала");
-    expect(result.showTitle).toBe("Название сериала (7 сезон: 1 серии из 7)");
+    expect(result.torrentId).toBe('778');
+    expect(result.rawTitle).toContain('Сериал / Название сериала');
+    expect(result.showTitle).toBe('Название сериала (7 сезон: 1 серии из 7)');
     expect(result.epAndSeason).toEqual({
       season: 7,
       startEp: 1,
       endEp: 1,
       totalEp: 7,
     });
-    expect(result.magnet).toBe("FEEDFACE5678");
+    expect(result.magnet).toBe('FEEDFACE5678');
   });
 
-  it("kinozal: parses episodes label without season colon", async () => {
+  it('kinozal: parses episodes label without season colon', async () => {
     const pageHtml = `
       <html>
         <body>
@@ -294,21 +432,21 @@ describe("TrackerData.collect", () => {
 
     class MockTrackerAuth extends TrackerAuth {
       public async getCookies(): Promise<string> {
-        return "sid=abc";
+        return 'sid=abc';
       }
     }
 
-    const url = "https://kinozal.tv/details.php?id=779";
+    const url = 'https://kinozal.tv/details.php?id=779';
     const trackerAuth = new MockTrackerAuth({
-      login: "login",
-      password: "pass",
-      baseUrl: "https://kinozal.tv",
-      tracker: "kinozal",
+      login: 'login',
+      password: 'pass',
+      baseUrl: 'https://kinozal.tv',
+      tracker: 'kinozal',
     });
 
     const td = new TrackerDataAdapter({
       url,
-      tracker: "kinozal",
+      tracker: 'kinozal',
       trackerAuth,
     });
     const result = await td.collect();
@@ -319,10 +457,10 @@ describe("TrackerData.collect", () => {
       endEp: 7,
       totalEp: 8,
     });
-    expect(result.magnet).toBe("DEADBEEF5678");
+    expect(result.magnet).toBe('DEADBEEF5678');
   });
 
-  it("nnmClub: parses data from anchor href (no auth)", async () => {
+  it('nnmClub: parses data from anchor href (no auth)', async () => {
     const topicHtml = `
       <html>
         <body>
@@ -336,22 +474,22 @@ describe("TrackerData.collect", () => {
     const mockedFetch = vi.mocked(customFetch);
     mockedFetch.mockResolvedValueOnce(toResponse(topicHtml));
 
-    const url = "https://nnmclub.to/forum/viewtopic.php?t=987";
-    const td = new TrackerDataAdapter({ url, tracker: "nnmClub" });
+    const url = 'https://nnmclub.to/forum/viewtopic.php?t=987';
+    const td = new TrackerDataAdapter({ url, tracker: 'nnmClub' });
     const result = await td.collect();
 
-    expect(result.torrentId).toBe("987");
-    expect(result.showTitle).toBe("Название шоу");
+    expect(result.torrentId).toBe('987');
+    expect(result.showTitle).toBe('Название шоу');
     expect(result.epAndSeason).toEqual({
       season: 3,
       startEp: 7,
       endEp: 9,
       totalEp: 12,
     });
-    expect(result.magnet).toBe("magnet:?xt=urn:btih:FACECAFE0011");
+    expect(result.magnet).toBe('magnet:?xt=urn:btih:FACECAFE0011');
   });
 
-  it("nnmClub: parses episodes label with slash separator", async () => {
+  it('nnmClub: parses episodes label with slash separator', async () => {
     const topicHtml = `
       <html>
         <body>
@@ -365,8 +503,8 @@ describe("TrackerData.collect", () => {
     const mockedFetch = vi.mocked(customFetch);
     mockedFetch.mockResolvedValueOnce(toResponse(topicHtml));
 
-    const url = "https://nnmclub.to/forum/viewtopic.php?t=988";
-    const td = new TrackerDataAdapter({ url, tracker: "nnmClub" });
+    const url = 'https://nnmclub.to/forum/viewtopic.php?t=988';
+    const td = new TrackerDataAdapter({ url, tracker: 'nnmClub' });
     const result = await td.collect();
 
     expect(result.epAndSeason).toEqual({
@@ -375,10 +513,10 @@ describe("TrackerData.collect", () => {
       endEp: 7,
       totalEp: 8,
     });
-    expect(result.magnet).toBe("magnet:?xt=urn:btih:FACECAFE0012");
+    expect(result.magnet).toBe('magnet:?xt=urn:btih:FACECAFE0012');
   });
 
-  it("rutracker: fallback parses magnet from text when href is empty", async () => {
+  it('rutracker: fallback parses magnet from text when href is empty', async () => {
     const topicHtml = `
       <html>
         <body>
@@ -392,24 +530,24 @@ describe("TrackerData.collect", () => {
     const mockedFetch = vi.mocked(customFetch);
     mockedFetch.mockResolvedValueOnce(toResponse(topicHtml));
 
-    const url = "https://rutracker.org/forum/viewtopic.php?t=111";
-    const td = new TrackerDataAdapter({ url, tracker: "rutracker" });
+    const url = 'https://rutracker.org/forum/viewtopic.php?t=111';
+    const td = new TrackerDataAdapter({ url, tracker: 'rutracker' });
     const result = await td.collect();
 
-    expect(result.torrentId).toBe("111");
-    expect(result.magnet).toBe("ABC123FF");
+    expect(result.torrentId).toBe('111');
+    expect(result.magnet).toBe('ABC123FF');
   });
 
-  it("throws when title is missing (no titleSelector match)", async () => {
+  it('throws when title is missing (no titleSelector match)', async () => {
     const htmlNoTitle = `<html><body><div>no-title-here</div></body></html>`;
     vi.mocked(customFetch).mockResolvedValueOnce(toResponse(htmlNoTitle));
 
-    const url = "https://rutracker.org/forum/viewtopic.php?t=1";
-    const td = new TrackerDataAdapter({ url, tracker: "rutracker" });
+    const url = 'https://rutracker.org/forum/viewtopic.php?t=1';
+    const td = new TrackerDataAdapter({ url, tracker: 'rutracker' });
     await expect(td.collect()).rejects.toThrow(/No raw title found/);
   });
 
-  it("throws when seasons/episodes pattern missing", async () => {
+  it('throws when seasons/episodes pattern missing', async () => {
     const html = `
       <html>
         <body>
@@ -418,32 +556,32 @@ describe("TrackerData.collect", () => {
       </html>`;
     vi.mocked(customFetch).mockResolvedValueOnce(toResponse(html));
 
-    const url = "https://rutracker.org/forum/viewtopic.php?t=2";
-    const td = new TrackerDataAdapter({ url, tracker: "rutracker" });
+    const url = 'https://rutracker.org/forum/viewtopic.php?t=2';
+    const td = new TrackerDataAdapter({ url, tracker: 'rutracker' });
     await expect(td.collect()).rejects.toThrow(/No episodes and season found/);
   });
 
-  it("throws when tracker id not found in URL", () => {
+  it('throws when tracker id not found in URL', () => {
     const create = () =>
       new TrackerDataAdapter({
-        url: "https://rutracker.org/forum/viewtopic.php",
-        tracker: "rutracker",
+        url: 'https://rutracker.org/forum/viewtopic.php',
+        tracker: 'rutracker',
       });
     expect(create).toThrow(/Tracker id not found/);
   });
 
-  it("throws when tracker is unknown", () => {
+  it('throws when tracker is unknown', () => {
     const badTracker =
-      "unknown" as unknown as keyof typeof import("@server/shared/trackers-conf").trackersConf;
+      'unknown' as unknown as keyof typeof import('@server/shared/trackers-conf').trackersConf;
     const create = () =>
       new TrackerDataAdapter({
-        url: "https://example.com",
+        url: 'https://example.com',
         tracker: badTracker,
       });
     expect(create).toThrow(/Tracker not found/);
   });
 
-  it("kinozal: cookie retrieval error propagates to collect()", async () => {
+  it('kinozal: cookie retrieval error propagates to collect()', async () => {
     const pageHtml = `
       <html>
         <body>
@@ -455,23 +593,23 @@ describe("TrackerData.collect", () => {
 
     class FailingAuth extends TrackerAuth {
       public async getCookies(): Promise<string> {
-        throw new Error("bad creds");
+        throw new Error('bad creds');
       }
     }
 
-    const url = "https://kinozal.tv/details.php?id=42";
+    const url = 'https://kinozal.tv/details.php?id=42';
     const trackerAuth = new FailingAuth({
-      login: "login",
-      password: "pass",
-      baseUrl: "https://kinozal.tv",
-      tracker: "kinozal",
+      login: 'login',
+      password: 'pass',
+      baseUrl: 'https://kinozal.tv',
+      tracker: 'kinozal',
     });
-    const td = new TrackerDataAdapter({ url, tracker: "kinozal", trackerAuth });
+    const td = new TrackerDataAdapter({ url, tracker: 'kinozal', trackerAuth });
 
     await expect(td.collect()).rejects.toThrow(/bad creds/);
   });
 
-  it("throws when magnet element exists but has no text", async () => {
+  it('throws when magnet element exists but has no text', async () => {
     const topicHtml = `
       <html>
         <body>
@@ -484,13 +622,13 @@ describe("TrackerData.collect", () => {
 
     vi.mocked(customFetch).mockResolvedValueOnce(toResponse(topicHtml));
 
-    const url = "https://rutracker.org/forum/viewtopic.php?t=555";
-    const td = new TrackerDataAdapter({ url, tracker: "rutracker" });
+    const url = 'https://rutracker.org/forum/viewtopic.php?t=555';
+    const td = new TrackerDataAdapter({ url, tracker: 'rutracker' });
 
     await expect(td.collect()).rejects.toThrow(/No magnet element found/);
   });
 
-  it("throws when magnet text does not match expected pattern", async () => {
+  it('throws when magnet text does not match expected pattern', async () => {
     const topicHtml = `
       <html>
         <body>
@@ -503,8 +641,8 @@ describe("TrackerData.collect", () => {
 
     vi.mocked(customFetch).mockResolvedValueOnce(toResponse(topicHtml));
 
-    const url = "https://rutracker.org/forum/viewtopic.php?t=556";
-    const td = new TrackerDataAdapter({ url, tracker: "rutracker" });
+    const url = 'https://rutracker.org/forum/viewtopic.php?t=556';
+    const td = new TrackerDataAdapter({ url, tracker: 'rutracker' });
 
     await expect(td.collect()).rejects.toThrow(/No magnet match found/);
   });

--- a/server/test/transmission-adapter.test.ts
+++ b/server/test/transmission-adapter.test.ts
@@ -35,6 +35,9 @@ const baseSettings: DbUserSettings = {
   jackettUrl: null,
   kinozalUsername: null,
   kinozalPassword: null,
+  flaresolverrEnabled: false,
+  flaresolverrUrl: null,
+  flaresolverrTimeoutSeconds: 60,
 };
 
 let nextSettings: DbUserSettings = { ...baseSettings };
@@ -69,7 +72,7 @@ class TransmissionMock {
 
   async addMagnet(
     magnet: string,
-    options: Record<string, unknown>
+    options: Record<string, unknown>,
   ): Promise<{ arguments: Record<string, unknown> }> {
     this.lastAddArgs = { magnet, options };
     return Promise.resolve({
@@ -79,7 +82,7 @@ class TransmissionMock {
 
   async removeTorrent(
     id: string,
-    deleteLocal: boolean
+    deleteLocal: boolean,
   ): Promise<Record<string, unknown>> {
     this.lastRemoveArgs = { id, deleteLocal };
     return Promise.resolve({ id, deleteLocal });
@@ -89,7 +92,9 @@ class TransmissionMock {
     return Promise.resolve({ id, name: 'some-torrent' });
   }
 
-  async listTorrents(): Promise<{ arguments: { torrents: Array<Record<string, unknown>> } }> {
+  async listTorrents(): Promise<{
+    arguments: { torrents: Array<Record<string, unknown>> };
+  }> {
     return Promise.resolve({ arguments: { torrents: [{ hashString: 'x1' }] } });
   }
 }
@@ -139,7 +144,10 @@ describe('TransmissionAdapter', () => {
 
     // Verifies item update
     expect(repo.updateTorrentItem).toHaveBeenCalledTimes(1);
-    const call = repo.updateTorrentItem.mock.calls[0] as [number, Partial<DbTorrentItem>];
+    const call = repo.updateTorrentItem.mock.calls[0] as [
+      number,
+      Partial<DbTorrentItem>,
+    ];
     const [idArg, dataArg] = call;
     expect(idArg).toBe(1);
     expect(dataArg).toMatchObject({
@@ -191,7 +199,10 @@ describe('TransmissionAdapter', () => {
     await adapter.add();
 
     expect(repo.updateTorrentItem).toHaveBeenCalledTimes(1);
-    const call2 = repo.updateTorrentItem.mock.calls[0] as [number, Partial<DbTorrentItem>];
+    const call2 = repo.updateTorrentItem.mock.calls[0] as [
+      number,
+      Partial<DbTorrentItem>,
+    ];
     const [, dataArg] = call2;
     expect(dataArg).toMatchObject({
       transmissionId: 'dup123',
@@ -225,7 +236,10 @@ describe('TransmissionAdapter', () => {
     await adapter.remove();
 
     expect(repo.updateTorrentItem).toHaveBeenCalledTimes(1);
-    const call3 = repo.updateTorrentItem.mock.calls[0] as [number, Partial<DbTorrentItem>];
+    const call3 = repo.updateTorrentItem.mock.calls[0] as [
+      number,
+      Partial<DbTorrentItem>,
+    ];
     const [, dataArg] = call3;
     expect(dataArg).toMatchObject({
       controlStatus: 'idle',
@@ -350,7 +364,7 @@ describe('TransmissionAdapter', () => {
     expect(client.lastAddArgs).toBeTruthy();
     expect(
       'download-dir' in
-        (client.lastAddArgs as NonNullable<typeof client.lastAddArgs>).options
+        (client.lastAddArgs as NonNullable<typeof client.lastAddArgs>).options,
     ).toBe(false);
   });
 
@@ -358,7 +372,7 @@ describe('TransmissionAdapter', () => {
     class TransmissionErrorMock extends TransmissionMock {
       override async addMagnet(
         _magnet: string,
-        _options: Record<string, unknown>
+        _options: Record<string, unknown>,
       ): Promise<{ arguments: Record<string, unknown> }> {
         throw new Error('boom');
       }
@@ -388,7 +402,7 @@ describe('TransmissionAdapter', () => {
     class TransmissionNoHashMock extends TransmissionMock {
       override async addMagnet(
         magnet: string,
-        options: Record<string, unknown>
+        options: Record<string, unknown>,
       ): Promise<{ arguments: Record<string, unknown> }> {
         this.lastAddArgs = { magnet, options };
         return Promise.resolve({ arguments: {} });
@@ -413,7 +427,7 @@ describe('TransmissionAdapter', () => {
     });
 
     await expect(adapter.add()).rejects.toThrow(
-      'Failed to add torrent: Transmission did not return hashString'
+      'Failed to add torrent: Transmission did not return hashString',
     );
   });
 
@@ -588,9 +602,9 @@ describe('TransmissionAdapter', () => {
           id: 1,
           client: client as unknown as Transmission,
           repo: repo as unknown as never,
-        })
+        }),
     ).toThrow(
-      'TRANSMISSION_BASE_URL, TRANSMISSION_USERNAME, TRANSMISSION_PASSWORD must be set in env'
+      'TRANSMISSION_BASE_URL, TRANSMISSION_USERNAME, TRANSMISSION_PASSWORD must be set in env',
     );
 
     // Restore envs for subsequent tests

--- a/server/test/update-worker-error-message.test.ts
+++ b/server/test/update-worker-error-message.test.ts
@@ -41,7 +41,12 @@ class MockTorrentItem {
   async markAsDownloadRequested(): Promise<void> {
     return;
   }
-  async getAll(): Promise<{ items: []; total: number; page: number; hasNext: boolean }> {
+  async getAll(): Promise<{
+    items: [];
+    total: number;
+    page: number;
+    hasNext: boolean;
+  }> {
     return { items: [], total: 0, page: 1, hasNext: false };
   }
   async updateTrackedEpisodes(_episodes: number[]): Promise<void> {
@@ -87,7 +92,10 @@ class RepoMock {
     return this.rows;
   }
 
-  async update(id: number, data: Partial<DbTorrentItem>): Promise<DbTorrentItem | undefined> {
+  async update(
+    id: number,
+    data: Partial<DbTorrentItem>,
+  ): Promise<DbTorrentItem | undefined> {
     this.updates.push({ id, data });
     return undefined;
   }
@@ -125,6 +133,9 @@ const settings: DbUserSettings = {
   jackettUrl: null,
   kinozalUsername: null,
   kinozalPassword: null,
+  flaresolverrEnabled: false,
+  flaresolverrUrl: null,
+  flaresolverrTimeoutSeconds: 60,
 };
 
 describe('UpdateWorker errorMessage handling', () => {
@@ -143,9 +154,13 @@ describe('UpdateWorker errorMessage handling', () => {
 
     await worker.process();
 
-    const errUpdate = repo.updates.find((u) => typeof u.data.errorMessage === 'string');
+    const errUpdate = repo.updates.find(
+      (u) => typeof u.data.errorMessage === 'string',
+    );
     expect(errUpdate).toBeDefined();
-    expect(String(errUpdate?.data.errorMessage)).toContain('Error on fetch data');
+    expect(String(errUpdate?.data.errorMessage)).toContain(
+      'Error on fetch data',
+    );
   });
 
   it('persists errorMessage when tracker title is missing', async () => {
@@ -156,9 +171,13 @@ describe('UpdateWorker errorMessage handling', () => {
 
     await worker.process();
 
-    const errUpdate = repo.updates.find((u) => typeof u.data.errorMessage === 'string');
+    const errUpdate = repo.updates.find(
+      (u) => typeof u.data.errorMessage === 'string',
+    );
     expect(errUpdate).toBeDefined();
-    expect(String(errUpdate?.data.errorMessage)).toContain('no tracker title found');
+    expect(String(errUpdate?.data.errorMessage)).toContain(
+      'no tracker title found',
+    );
   });
 
   it('clears UpdateWorker errorMessage on successful iteration', async () => {
@@ -166,13 +185,15 @@ describe('UpdateWorker errorMessage handling', () => {
     mode = 'success';
     const repo = new RepoMock(
       [{ ...baseItem, errorMessage: 'UpdateWorker: prev' }],
-      settings
+      settings,
     );
     const worker = new UpdateWorker({ repo: repo as unknown as never });
 
     await worker.process();
 
-    const clearUpdate = repo.updates.find((u) => Object.prototype.hasOwnProperty.call(u.data, 'errorMessage'));
+    const clearUpdate = repo.updates.find((u) =>
+      Object.prototype.hasOwnProperty.call(u.data, 'errorMessage'),
+    );
     expect(clearUpdate).toBeDefined();
     expect(clearUpdate?.data.errorMessage).toBeNull();
   });
@@ -182,14 +203,14 @@ describe('UpdateWorker errorMessage handling', () => {
     mode = 'success';
     const repo = new RepoMock(
       [{ ...baseItem, errorMessage: 'DownloadWorker: prev' }],
-      settings
+      settings,
     );
     const worker = new UpdateWorker({ repo: repo as unknown as never });
 
     await worker.process();
 
     const clearUpdate = repo.updates.find((u) =>
-      Object.prototype.hasOwnProperty.call(u.data, 'errorMessage')
+      Object.prototype.hasOwnProperty.call(u.data, 'errorMessage'),
     );
     expect(clearUpdate).toBeUndefined();
   });

--- a/server/test/update-worker.test.ts
+++ b/server/test/update-worker.test.ts
@@ -62,6 +62,9 @@ const settings: DbUserSettings = {
   jackettUrl: null,
   kinozalUsername: null,
   kinozalPassword: null,
+  flaresolverrEnabled: false,
+  flaresolverrUrl: null,
+  flaresolverrTimeoutSeconds: 60,
 };
 
 // Capture latest created TorrentItem instance for assertions
@@ -94,7 +97,7 @@ vi.mock('@server/features/torrent-item/torrent-item.service', () => {
     }
     async getAll(
       page: number,
-      limit: number
+      limit: number,
     ): Promise<PagedResult<TorrentItemDto>> {
       void limit;
       return Promise.resolve({

--- a/server/test/workers.repo.test.ts
+++ b/server/test/workers.repo.test.ts
@@ -23,7 +23,7 @@ const updateSetCalls: Array<Partial<DbTorrentItemInsert>> = [];
 type Awaitable<T> = {
   then: (
     onFulfilled?: ((value: T) => unknown) | null,
-    onRejected?: ((reason: unknown) => unknown) | null
+    onRejected?: ((reason: unknown) => unknown) | null,
   ) => Promise<unknown>;
   catch: (onRejected: (reason: unknown) => unknown) => Promise<unknown>;
   finally: (onFinally: () => void) => Promise<unknown>;
@@ -31,13 +31,16 @@ type Awaitable<T> = {
 
 const makeAwaitable = <T>(value: T): Awaitable<T> => ({
   then: (onFulfilled, onRejected) =>
-    Promise.resolve(value).then(onFulfilled ?? undefined, onRejected ?? undefined),
+    Promise.resolve(value).then(
+      onFulfilled ?? undefined,
+      onRejected ?? undefined,
+    ),
   catch: (onRejected) => Promise.resolve(value).catch(onRejected),
   finally: (onFinally) => Promise.resolve(value).finally(onFinally),
 });
 
 const makeAwaitableFrom = (
-  rows: Array<DbTorrentItem | DbUserSettings> | null
+  rows: Array<DbTorrentItem | DbUserSettings> | null,
 ) => {
   const awaitable = makeAwaitable(rows ?? []);
   return Object.assign(awaitable, {
@@ -74,9 +77,7 @@ const repo = new WorkersRepo({
   $client: {} as unknown as Database,
 } as unknown as BunSQLiteDatabase & { $client: Database });
 
-function makeTorrent(
-  override: Partial<DbTorrentItem> = {}
-): DbTorrentItem {
+function makeTorrent(override: Partial<DbTorrentItem> = {}): DbTorrentItem {
   return {
     id: 1,
     trackerId: 'tid-1',
@@ -99,9 +100,7 @@ function makeTorrent(
   } satisfies DbTorrentItem;
 }
 
-function makeSettings(
-  override: Partial<DbUserSettings> = {}
-): DbUserSettings {
+function makeSettings(override: Partial<DbUserSettings> = {}): DbUserSettings {
   return {
     id: 1,
     telegramId: 123,
@@ -114,6 +113,9 @@ function makeSettings(
     jackettUrl: null,
     kinozalUsername: null,
     kinozalPassword: null,
+    flaresolverrEnabled: false,
+    flaresolverrUrl: null,
+    flaresolverrTimeoutSeconds: 60,
     ...override,
   } satisfies DbUserSettings;
 }
@@ -162,10 +164,7 @@ describe('WorkersRepo (mocked database)', () => {
   });
 
   it('warns when more than one settings row exists', async () => {
-    selectFromQueue.push([
-      makeSettings({ id: 1 }),
-      makeSettings({ id: 2 }),
-    ]);
+    selectFromQueue.push([makeSettings({ id: 1 }), makeSettings({ id: 2 })]);
 
     const settings = await repo.findSettings();
 
@@ -178,7 +177,9 @@ describe('WorkersRepo (mocked database)', () => {
 
     await repo.markAsCompleted(5);
 
-    expect(updateSetCalls.at(-1)).toMatchObject({ controlStatus: 'downloadCompleted' });
+    expect(updateSetCalls.at(-1)).toMatchObject({
+      controlStatus: 'downloadCompleted',
+    });
   });
 
   it('marks record as processing', async () => {
@@ -186,7 +187,9 @@ describe('WorkersRepo (mocked database)', () => {
 
     await repo.markAsProcessing(3);
 
-    expect(updateSetCalls.at(-1)).toMatchObject({ controlStatus: 'processing' });
+    expect(updateSetCalls.at(-1)).toMatchObject({
+      controlStatus: 'processing',
+    });
   });
 
   it('resets record to idle and clears transmissionId', async () => {


### PR DESCRIPTION
## Summary
- Add FlareSolverr settings for enabling Cloudflare bypass, server URL, timeout, and connection testing.
- Add FlareSolverr-backed fallback when tracker pages return Cloudflare challenge HTML.
- Add SQLite migrations and tests for settings, verification route, and tracker fallback behavior.

## Rationale
Some tracker topic pages can be blocked by Cloudflare checks. This adds an opt-in browser-solving fallback without slowing down the normal tracker fetch path.

## Changes
- Client settings UI for FlareSolverr enablement, URL, timeout, and connection check.
- Server route `/api/flaresolverr/verify` using FlareSolverr `sessions.list`.
- Tracker data fallback through FlareSolverr when Cloudflare challenge pages are detected.
- New settings fields and migrations: `flaresolverr_enabled`, `flaresolverr_url`, `flaresolverr_timeout_seconds`.

## Validation
- `bun run lint` passed with existing warnings only.
- `bun run test` passed.
- `bun run build` passed.
- Local dev migrations applied successfully.