### PR TITLE
feat: add per-torrent notifications

### DIFF
--- a/client/src/components/EditTorrentDialog/NotificationSettings.tsx
+++ b/client/src/components/EditTorrentDialog/NotificationSettings.tsx
@@ -1,0 +1,82 @@
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+import type { TorrentItemDto } from '@server/features/torrent-item/torrent-item.types';
+
+export type NotificationSettingsValue = Pick<
+  TorrentItemDto,
+  'notifyOnTitleChange' | 'notifyOnMagnetChange' | 'notifyOnDownloadComplete'
+>;
+
+type NotificationSettingsProps = {
+  value: NotificationSettingsValue;
+  disabled: boolean;
+  onChange: (value: NotificationSettingsValue) => void;
+};
+
+export default function NotificationSettings({
+  value,
+  disabled,
+  onChange,
+}: NotificationSettingsProps) {
+  return (
+    <div className='flex flex-col gap-4 py-2'>
+      <NotificationOption
+        id='notify-title-change'
+        label='When title changes'
+        checked={value.notifyOnTitleChange}
+        disabled={disabled}
+        onCheckedChange={(checked) =>
+          onChange({ ...value, notifyOnTitleChange: checked })
+        }
+      />
+      <NotificationOption
+        id='notify-magnet-change'
+        label='When magnet changes'
+        checked={value.notifyOnMagnetChange}
+        disabled={disabled}
+        onCheckedChange={(checked) =>
+          onChange({ ...value, notifyOnMagnetChange: checked })
+        }
+      />
+      <NotificationOption
+        id='notify-download-complete'
+        label='When download completes'
+        checked={value.notifyOnDownloadComplete}
+        disabled={disabled}
+        onCheckedChange={(checked) =>
+          onChange({ ...value, notifyOnDownloadComplete: checked })
+        }
+      />
+    </div>
+  );
+}
+
+// --- Option ---------------------------------------------------------------
+
+function NotificationOption({
+  id,
+  label,
+  checked,
+  disabled,
+  onCheckedChange,
+}: {
+  id: string;
+  label: string;
+  checked: boolean;
+  disabled: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}) {
+  return (
+    <div className='flex items-center gap-3'>
+      <Checkbox
+        id={id}
+        checked={checked}
+        disabled={disabled}
+        onCheckedChange={(nextValue) => onCheckedChange(nextValue === true)}
+      />
+      <Label htmlFor={id} className='cursor-pointer text-sm text-zinc-300'>
+        {label}
+      </Label>
+    </div>
+  );
+}

--- a/client/src/components/EditTorrentDialog/Tabs.tsx
+++ b/client/src/components/EditTorrentDialog/Tabs.tsx
@@ -1,15 +1,19 @@
 import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { PopcornIcon, FileVideo } from 'lucide-react';
+import { Bell, PopcornIcon, FileVideo } from 'lucide-react';
 
 export default function DataTabs({
   torrents,
   files,
   filesData,
+  notifications,
+  notificationsEnabled,
 }: {
   torrents: React.ReactNode;
   files: React.ReactNode;
   filesData: string[];
+  notifications: React.ReactNode;
+  notificationsEnabled: boolean;
 }) {
   return (
     <Tabs defaultValue='tab-1'>
@@ -26,6 +30,19 @@ export default function DataTabs({
               aria-hidden='true'
             />
             Episodes
+          </TabsTrigger>
+          <TabsTrigger
+            disabled={!notificationsEnabled}
+            value='tab-3'
+            className='overflow-hidden rounded-b-none border-x border-t border-border bg-zinc-900 py-2 data-[state=active]:z-10 data-[state=active]:shadow-none cursor-pointer'
+          >
+            <Bell
+              className='-ms-0.5 me-1.5 opacity-60'
+              size={16}
+              strokeWidth={2}
+              aria-hidden='true'
+            />
+            Notifications
           </TabsTrigger>
           <TabsTrigger
             disabled={filesData.length === 0}
@@ -46,6 +63,7 @@ export default function DataTabs({
 
       <TabsContent value='tab-1'>{torrents}</TabsContent>
       <TabsContent value='tab-2'>{files}</TabsContent>
+      <TabsContent value='tab-3'>{notifications}</TabsContent>
     </Tabs>
   );
 }

--- a/client/src/components/EditTorrentDialog/index.tsx
+++ b/client/src/components/EditTorrentDialog/index.tsx
@@ -19,6 +19,10 @@ import { useTorrentStore } from '@/stores/torrentStore';
 import { rpc } from '@/lib/rpc';
 import customSonner from '@/components/CustomSonner';
 import { useNavigate } from 'react-router';
+import useSettings from '@/hooks/useSettings';
+import NotificationSettings, {
+  type NotificationSettingsValue,
+} from './NotificationSettings';
 
 type EpisodesObj = {
   id: number;
@@ -41,6 +45,7 @@ export default function EditTorrentDialog({
   const [isAddingToClient, setIsAddingToClient] = useState(false);
   const [isRemovingFromClient, setIsRemovingFromClient] = useState(false);
   const navigate = useNavigate();
+  const { settingsData } = useSettings(dialogOpen);
 
   const setOpenId = useTorrentStore((state) => state.setOpenId);
   const setStartFetch = useTorrentStore((state) => state.setStartFetch);
@@ -197,10 +202,14 @@ export default function EditTorrentDialog({
         {data && (
           <>
             <DialogHeaderContent
+              key={data.id}
               data={data}
               episodesObj={episodesObj}
               handleSave={saveTrackedEpisodes}
               handleTitleSearch={handleTitleSearch}
+              telegramConfigured={Boolean(
+                settingsData?.botToken && settingsData.telegramId,
+              )}
             />
             <DialogFooterContent
               data={data}
@@ -268,6 +277,7 @@ function DialogHeaderContent({
   episodesObj,
   handleSave,
   handleTitleSearch,
+  telegramConfigured,
 }: {
   data: TorrentItemDto;
   episodesObj: {
@@ -279,7 +289,45 @@ function DialogHeaderContent({
   }[];
   handleSave: (id: number, episodes: number[]) => Promise<void>;
   handleTitleSearch: (torrent: TorrentItemDto) => void;
+  telegramConfigured: boolean;
 }) {
+  const [notificationsSaving, setNotificationsSaving] = useState(false);
+  const [notificationSettings, setNotificationSettings] =
+    useState<NotificationSettingsValue>(data);
+
+  const handleNotificationsChange = async (
+    value: NotificationSettingsValue,
+  ) => {
+    const previousValue = notificationSettings;
+    setNotificationSettings(value);
+    setNotificationsSaving(true);
+    try {
+      const response = await (
+        await rpc.api.torrents[':id']['save-notifications'].$put({
+          param: { id: String(data.id) },
+          json: value,
+        })
+      ).json();
+      if (!response.success) {
+        customSonner({
+          variant: 'error',
+          text: response.message || 'Failed to save notification settings',
+        });
+        setNotificationSettings(previousValue);
+        return;
+      }
+      useTorrentStore.getState().setStartFetch(Date.now());
+    } catch (error) {
+      customSonner({
+        variant: 'error',
+        text: `Failed to save notification settings: ${(error as Error).message}`,
+      });
+      setNotificationSettings(previousValue);
+    } finally {
+      setNotificationsSaving(false);
+    }
+  };
+
   return (
     <DialogHeader className='flex space-y-0 text-left overflow-hidden'>
       <DialogTitle className='border-b border-border px-6 py-4 text-base font-black hidden'>
@@ -320,6 +368,7 @@ function DialogHeaderContent({
             </div>
             <DataTabs
               filesData={data.files as string[]}
+              notificationsEnabled={telegramConfigured}
               torrents={
                 <EpPicker
                   itemId={data.id}
@@ -329,6 +378,13 @@ function DialogHeaderContent({
               }
               files={
                 <FileList files={data.files as string[]} torrentId={data.id} />
+              }
+              notifications={
+                <NotificationSettings
+                  value={notificationSettings}
+                  disabled={notificationsSaving}
+                  onChange={handleNotificationsChange}
+                />
               }
             />
           </div>

--- a/client/src/hooks/useSettings.ts
+++ b/client/src/hooks/useSettings.ts
@@ -5,7 +5,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 type SettingsData = DbUserSettings | null;
 
-export default function useSettings() {
+export default function useSettings(enabled: boolean = true) {
   const queryClient = useQueryClient();
   const {
     data: settingsData,
@@ -19,6 +19,7 @@ export default function useSettings() {
     refetchOnMount: true,
     refetchOnWindowFocus: true,
     refetchInterval: 10000,
+    enabled,
     queryFn: async () => {
       const resp = await rpc.api.settings.$get();
       const payload = await resp.json();

--- a/server/src/db/app/app-schema.ts
+++ b/server/src/db/app/app-schema.ts
@@ -58,6 +58,17 @@ export const torrentItems = sqliteTable(
       enum: Object.keys(trackersConf) as [string, ...string[]],
     }).notNull(),
     errorMessage: text('error_message'),
+    notifyOnTitleChange: int('notify_on_title_change', { mode: 'boolean' })
+      .default(false)
+      .notNull(),
+    notifyOnMagnetChange: int('notify_on_magnet_change', { mode: 'boolean' })
+      .default(false)
+      .notNull(),
+    notifyOnDownloadComplete: int('notify_on_download_complete', {
+      mode: 'boolean',
+    })
+      .default(true)
+      .notNull(),
   },
   (t) => [index('tracker_index').on(t.tracker)],
 );

--- a/server/src/db/migrations/0006_add_torrent_notifications.sql
+++ b/server/src/db/migrations/0006_add_torrent_notifications.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `torrent_items` ADD `notify_on_title_change` integer DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE `torrent_items` ADD `notify_on_magnet_change` integer DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE `torrent_items` ADD `notify_on_download_complete` integer DEFAULT true NOT NULL;

--- a/server/src/db/migrations/meta/0006_snapshot.json
+++ b/server/src/db/migrations/meta/0006_snapshot.json
@@ -1,0 +1,751 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "b3168f74-a793-4981-b6fa-4e844df45921",
+  "prevId": "b750a3cc-ef30-40d8-99bb-8698787dc00e",
+  "tables": {
+    "event_journal": {
+      "name": "event_journal",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'info'"
+        },
+        "torrent_item_id": {
+          "name": "torrent_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "torrent_title": {
+          "name": "torrent_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "old_value": {
+          "name": "old_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_notification": {
+          "name": "is_notification",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {
+        "event_journal_created_at_index": {
+          "name": "event_journal_created_at_index",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "event_journal_read_at_index": {
+          "name": "event_journal_read_at_index",
+          "columns": [
+            "read_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "event_journal_torrent_item_id_torrent_items_id_fk": {
+          "name": "event_journal_torrent_item_id_torrent_items_id_fk",
+          "tableFrom": "event_journal",
+          "tableTo": "torrent_items",
+          "columnsFrom": [
+            "torrent_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "torrent_items": {
+      "name": "torrent_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "tracker_id": {
+          "name": "tracker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_title": {
+          "name": "raw_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "magnet": {
+          "name": "magnet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "season": {
+          "name": "season",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tracked_episodes": {
+          "name": "tracked_episodes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "have_episodes": {
+          "name": "have_episodes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "total_episodes": {
+          "name": "total_episodes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "files": {
+          "name": "files",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        },
+        "transmission_id": {
+          "name": "transmission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "control_status": {
+          "name": "control_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'idle'"
+        },
+        "tracker": {
+          "name": "tracker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notify_on_title_change": {
+          "name": "notify_on_title_change",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "notify_on_magnet_change": {
+          "name": "notify_on_magnet_change",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "notify_on_download_complete": {
+          "name": "notify_on_download_complete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "torrent_items_tracker_id_unique": {
+          "name": "torrent_items_tracker_id_unique",
+          "columns": [
+            "tracker_id"
+          ],
+          "isUnique": true
+        },
+        "torrent_items_url_unique": {
+          "name": "torrent_items_url_unique",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        },
+        "torrent_items_transmission_id_unique": {
+          "name": "torrent_items_transmission_id_unique",
+          "columns": [
+            "transmission_id"
+          ],
+          "isUnique": true
+        },
+        "tracker_index": {
+          "name": "tracker_index",
+          "columns": [
+            "tracker"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "telegram_id": {
+          "name": "telegram_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bot_token": {
+          "name": "bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "download_dir": {
+          "name": "download_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_dir": {
+          "name": "media_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delete_after_download": {
+          "name": "delete_after_download",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "sync_interval": {
+          "name": "sync_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "jackett_api_key": {
+          "name": "jackett_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "jackett_url": {
+          "name": "jackett_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kinozal_username": {
+          "name": "kinozal_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kinozal_password": {
+          "name": "kinozal_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "flaresolverr_enabled": {
+          "name": "flaresolverr_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "flaresolverr_url": {
+          "name": "flaresolverr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "flaresolverr_timeout_seconds": {
+          "name": "flaresolverr_timeout_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 60
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/server/src/db/migrations/meta/_journal.json
+++ b/server/src/db/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1782277200000,
       "tag": "0005_add_event_journal_notification_flag",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1784378223291,
+      "tag": "0006_add_torrent_notifications",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/external/adapters/telegram/telegram.adapter.ts
+++ b/server/src/external/adapters/telegram/telegram.adapter.ts
@@ -82,4 +82,11 @@ export class TelegramAdapter {
       text,
     });
   }
+
+  public async sendMessage(text: string): Promise<TelegramMessage> {
+    return this.callApi<TelegramMessage>('sendMessage', {
+      chat_id: this.chatId,
+      text,
+    });
+  }
 }

--- a/server/src/features/torrent-item/torrent-item.mappers.ts
+++ b/server/src/features/torrent-item/torrent-item.mappers.ts
@@ -19,6 +19,9 @@ export function toTorrentItemDto(row: DbTorrentItem): TorrentItemDto {
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
     errorMessage: row.errorMessage,
+    notifyOnTitleChange: row.notifyOnTitleChange,
+    notifyOnMagnetChange: row.notifyOnMagnetChange,
+    notifyOnDownloadComplete: row.notifyOnDownloadComplete,
   };
 }
 

--- a/server/src/features/torrent-item/torrent-item.service.ts
+++ b/server/src/features/torrent-item/torrent-item.service.ts
@@ -137,6 +137,18 @@ export class TorrentItem implements TorrentItemPort {
     });
   }
 
+  async updateNotifications(
+    settings: Pick<
+      DbTorrentItem,
+      | 'notifyOnTitleChange'
+      | 'notifyOnMagnetChange'
+      | 'notifyOnDownloadComplete'
+    >,
+  ) {
+    if (!this.id) throw new Error('ID is not defined');
+    await this.repo.update(this.id, settings);
+  }
+
   async setAllEpisodesTracked() {
     if (!this.id) throw new Error('ID is not defined');
     await this.repo.update(this.id, {

--- a/server/src/features/torrent-item/torrent-item.types.ts
+++ b/server/src/features/torrent-item/torrent-item.types.ts
@@ -16,6 +16,9 @@ export type TorrentItemDto = {
   trackedEpisodes: number[];
   magnet: string | null;
   errorMessage: string | null;
+  notifyOnTitleChange: boolean;
+  notifyOnMagnetChange: boolean;
+  notifyOnDownloadComplete: boolean;
   controlStatus: (typeof controlStatuses)[number];
   createdAt: number;
   updatedAt: number;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -13,6 +13,7 @@ import { torrentsSyncRoute } from './routes/torrents.sync';
 import { torrentsDeleteRoute } from './routes/torrents.$id.delete';
 import { torrentsRoute } from './routes/torrents';
 import { torrentsSaveTrackedEpRoute } from './routes/torrents.save-tracked-ep';
+import { torrentsSaveNotificationsRoute } from './routes/torrents.save-notifications';
 import { torrentClientAddRoute } from './routes/torrent-client.$id.add';
 import { torrentClientDeleteRoute } from './routes/torrent-client.$id.delete';
 import { torrentClientRoute } from './routes/torrent-client';
@@ -99,6 +100,7 @@ export const routes = app
   .route('/torrents/add', torrentsAddRoute)
   .route('/torrents/:id/delete', torrentsDeleteRoute)
   .route('/torrents/:id/save-tracked-ep', torrentsSaveTrackedEpRoute)
+  .route('/torrents/:id/save-notifications', torrentsSaveNotificationsRoute)
   .route('/torrents/:id/pause-toggle', torrentsPauseToggleRoute)
   .route('/torrent-client', torrentClientRoute)
   .route('/torrent-client/:id/action', torrentClientActionRoute)

--- a/server/src/routes/torrents.save-notifications.ts
+++ b/server/src/routes/torrents.save-notifications.ts
@@ -1,0 +1,44 @@
+import { Hono } from 'hono/tiny';
+import type { ApiResponse } from 'shared/dist';
+import { TorrentItem } from '@server/features/torrent-item/torrent-item.service';
+import logger from '@server/lib/logger';
+import { z } from 'zod';
+import { sValidator } from '@hono/standard-validator';
+import { handleStandardValidation } from '@server/lib/validation';
+
+const paramSchema = z.object({
+  id: z.coerce.number().min(1),
+});
+
+const jsonSchema = z.object({
+  notifyOnTitleChange: z.boolean(),
+  notifyOnMagnetChange: z.boolean(),
+  notifyOnDownloadComplete: z.boolean(),
+});
+
+export const torrentsSaveNotificationsRoute = new Hono().put(
+  '/',
+  sValidator('param', paramSchema, handleStandardValidation),
+  sValidator('json', jsonSchema, handleStandardValidation),
+  async (c) => {
+    const settings = c.req.valid('json');
+    const { id } = c.req.valid('param');
+
+    try {
+      await new TorrentItem({ id }).updateNotifications(settings);
+      return c.json<ApiResponse<null>>({
+        success: true,
+        message: 'Notification settings updated',
+      });
+    } catch (error) {
+      logger.error(error);
+      return c.json<ApiResponse<null>>(
+        {
+          success: false,
+          message: error instanceof Error ? error.message : 'Update failed',
+        },
+        400,
+      );
+    }
+  },
+);

--- a/server/src/workers/download-worker.ts
+++ b/server/src/workers/download-worker.ts
@@ -246,8 +246,22 @@ export class DownloadWorker {
         torrentItem: row,
         message: formatCopiedFilesMessage(newFiles),
       });
-      if (this.settings?.telegramId && this.settings?.botToken)
-        new TelegramAdapter(this.settings).sendUpdate(row.title, copyResult);
+      if (
+        row.notifyOnDownloadComplete &&
+        this.settings?.telegramId &&
+        this.settings?.botToken
+      ) {
+        try {
+          await new TelegramAdapter(this.settings).sendUpdate(
+            row.title,
+            copyResult,
+          );
+        } catch (error) {
+          logger.error(
+            `[DownloadWorker] Failed to send Telegram notification: ${formatErrorMessage(error)}`,
+          );
+        }
+      }
     } catch (e) {
       logger.error(e);
       await this.repo.markAsIdle(row.id);

--- a/server/src/workers/update-worker.ts
+++ b/server/src/workers/update-worker.ts
@@ -5,7 +5,8 @@ import logger from '@server/lib/logger';
 import { formatErrorMessage } from '@server/lib/error-message';
 import { EventJournalService } from '@server/features/event-journal/event-journal.service';
 import type { EventJournalPort } from '@server/features/event-journal/event-journal.port';
-import type { DbTorrentItem } from '@server/db/app/app-schema';
+import type { DbTorrentItem, DbUserSettings } from '@server/db/app/app-schema';
+import { TelegramAdapter } from '@server/external/adapters/telegram';
 
 export class UpdateWorker {
   // Repository used to read settings and torrent items from DB
@@ -21,6 +22,7 @@ export class UpdateWorker {
   private intervalId: ReturnType<typeof setInterval> | null = null;
   // Prevent concurrent runs of process()
   private isProcessing = false;
+  private settings: DbUserSettings | null = null;
 
   constructor({
     repo,
@@ -44,6 +46,7 @@ export class UpdateWorker {
   private async getSetting() {
     const settings = await this.repo.findSettings();
     if (!settings) throw new Error('No settings found');
+    this.settings = settings;
     // Convert minutes from settings into milliseconds for scheduling
     this.syncInterval = settings.syncInterval * 60 * 1000;
     return settings;
@@ -193,6 +196,17 @@ export class UpdateWorker {
       });
       // Persist new tracker data
       await ti.addOrUpdate();
+      if (databaseData.notifyOnTitleChange) {
+        await this.sendNotification(trackerData.showTitle);
+      }
+      if (
+        trackerData.magnet !== databaseData.magnet &&
+        databaseData.notifyOnMagnetChange
+      ) {
+        await this.sendNotification(
+          `Magnet changed for "${trackerData.showTitle}"`,
+        );
+      }
 
       // If any tracked episode is present in the new torrent — request download
       const updatedDatabaseData = ti.databaseData ?? databaseData;
@@ -222,6 +236,11 @@ export class UpdateWorker {
         newValue: trackerData.magnet,
       });
       await ti.addOrUpdate();
+      if (databaseData.notifyOnMagnetChange) {
+        await this.sendNotification(
+          `Magnet changed for "${databaseData.title}"`,
+        );
+      }
     } else {
       logger.info(`[UpdateWorker] No new data found for ${databaseData.title}`);
     }
@@ -231,6 +250,17 @@ export class UpdateWorker {
       if (isUpdateWorkerError) {
         await this.repo.update(row.id, { errorMessage: null });
       }
+    }
+  }
+
+  private async sendNotification(message: string): Promise<void> {
+    if (!this.settings?.telegramId || !this.settings.botToken) return;
+    try {
+      await new TelegramAdapter(this.settings).sendMessage(message);
+    } catch (error) {
+      logger.error(
+        `[UpdateWorker] Failed to send Telegram notification: ${formatErrorMessage(error)}`,
+      );
     }
   }
 }

--- a/server/src/workers/update-worker.ts
+++ b/server/src/workers/update-worker.ts
@@ -197,7 +197,9 @@ export class UpdateWorker {
       // Persist new tracker data
       await ti.addOrUpdate();
       if (databaseData.notifyOnTitleChange) {
-        await this.sendNotification(trackerData.showTitle);
+        await this.sendNotification(
+          `New release for "${trackerData.showTitle}": ${trackerData.rawTitle}`,
+        );
       }
       if (
         trackerData.magnet !== databaseData.magnet &&

--- a/server/test/download-worker-copy-error.test.ts
+++ b/server/test/download-worker-copy-error.test.ts
@@ -160,6 +160,9 @@ describe('DownloadWorker copy failure persists errorMessage', () => {
     controlStatus: 'downloadCompleted',
     tracker: 'rutracker',
     errorMessage: null,
+    notifyOnTitleChange: false,
+    notifyOnMagnetChange: false,
+    notifyOnDownloadComplete: true,
   } as const;
 
   const settings: DbUserSettings = {

--- a/server/test/download-worker-error-message.test.ts
+++ b/server/test/download-worker-error-message.test.ts
@@ -148,6 +148,9 @@ const baseItem: DbTorrentItem = {
   controlStatus: 'idle',
   tracker: 'kinozal',
   errorMessage: null,
+  notifyOnTitleChange: false,
+  notifyOnMagnetChange: false,
+  notifyOnDownloadComplete: true,
 };
 
 const settings: DbUserSettings = {

--- a/server/test/download-worker.test.ts
+++ b/server/test/download-worker.test.ts
@@ -80,6 +80,9 @@ const item: DbTorrentItem = {
   controlStatus: 'idle',
   tracker: 'kinozal',
   errorMessage: null,
+  notifyOnTitleChange: false,
+  notifyOnMagnetChange: false,
+  notifyOnDownloadComplete: true,
 };
 
 const settings: DbUserSettings = {
@@ -113,10 +116,13 @@ const selectEpisodes = vi.fn(
   async (_downloadStatus: NormalizedTorrent) => undefined,
 );
 const remove = vi.fn(async () => undefined);
-const sendUpdate = vi.fn((title: string, payload: Record<number, string>) => {
-  void title;
-  void payload;
-});
+const sendUpdate = vi.fn(
+  async (title: string, payload: Record<number, string>) => {
+    void title;
+    void payload;
+    return Promise.resolve();
+  },
+);
 
 vi.mock('@server/external/adapters/transmission', () => ({
   TransmissionAdapter: class {
@@ -598,6 +604,57 @@ describe('DownloadWorker', () => {
     });
 
     expect(sendUpdate).toHaveBeenCalledWith(item.title, copyResult);
+  });
+
+  it('processCompletedDownload: skips disabled Telegram updates', async () => {
+    const { DownloadWorker } = await import('@server/workers/download-worker');
+    const repo = new RepoMock();
+    const worker = new DownloadWorker({ repo: repo as unknown as never });
+    const telegramSettings: DbUserSettings = {
+      ...settings,
+      telegramId: 123,
+      botToken: 'token',
+    };
+
+    repo.findAllNeedToControl.mockResolvedValueOnce([]);
+    repo.findSettings.mockResolvedValueOnce(telegramSettings);
+    await worker.process();
+    sendUpdate.mockClear();
+
+    await worker.processCompletedDownload({
+      ...item,
+      notifyOnDownloadComplete: false,
+      trackedEpisodes: [],
+      files: [],
+    });
+
+    expect(sendUpdate).not.toHaveBeenCalled();
+  });
+
+  it('processCompletedDownload: handles Telegram failures', async () => {
+    const { DownloadWorker } = await import('@server/workers/download-worker');
+    const repo = new RepoMock();
+    const worker = new DownloadWorker({ repo: repo as unknown as never });
+    const telegramSettings: DbUserSettings = {
+      ...settings,
+      telegramId: 123,
+      botToken: 'token',
+    };
+
+    repo.findAllNeedToControl.mockResolvedValueOnce([]);
+    repo.findSettings.mockResolvedValueOnce(telegramSettings);
+    await worker.process();
+    sendUpdate.mockRejectedValueOnce(new Error('Telegram unavailable'));
+
+    await expect(
+      worker.processCompletedDownload({
+        ...item,
+        trackedEpisodes: [],
+        files: [],
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(repo.markAsIdle).not.toHaveBeenCalled();
   });
 
   it('run: schedules processing and clears previous interval', async () => {

--- a/server/test/event-journal.service.test.ts
+++ b/server/test/event-journal.service.test.ts
@@ -53,6 +53,9 @@ const torrentItem: DbTorrentItem = {
   controlStatus: 'idle',
   tracker: 'kinozal',
   errorMessage: null,
+  notifyOnTitleChange: false,
+  notifyOnMagnetChange: false,
+  notifyOnDownloadComplete: true,
 };
 
 describe('EventJournalService', () => {

--- a/server/test/routes/torrents-routes.test.ts
+++ b/server/test/routes/torrents-routes.test.ts
@@ -126,6 +126,9 @@ function createTorrentDto(
     createdAt: Date.now(),
     updatedAt: Date.now(),
     errorMessage: null,
+    notifyOnTitleChange: false,
+    notifyOnMagnetChange: false,
+    notifyOnDownloadComplete: true,
     ...override,
   } satisfies TorrentItemDto;
 }

--- a/server/test/telegram-adapter.test.ts
+++ b/server/test/telegram-adapter.test.ts
@@ -83,6 +83,25 @@ describe('TelegramAdapter', () => {
     expect(result).toEqual(okResponsePayload.result);
   });
 
+  it('sendMessage sends provided text', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(okResponsePayload), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await new TelegramAdapter(baseSettings).sendMessage('New title');
+
+    const call = fetchMock.mock.calls[0] as [string, RequestInit];
+    const payload = JSON.parse(call[1].body as string) as {
+      chat_id: string;
+      text: string;
+    };
+    expect(payload).toEqual({ chat_id: '123456', text: 'New title' });
+  });
+
   it('sendUpdate throws on non-ok HTTP response', async () => {
     const fetchMock = vi
       .fn()

--- a/server/test/torrent-item.repo.test.ts
+++ b/server/test/torrent-item.repo.test.ts
@@ -87,6 +87,9 @@ function makeRow(override: Partial<DbTorrentItem> = {}): DbTorrentItem {
     controlStatus: 'idle',
     tracker: 'kinozal',
     errorMessage: null,
+    notifyOnTitleChange: false,
+    notifyOnMagnetChange: false,
+    notifyOnDownloadComplete: true,
     ...override,
   } satisfies DbTorrentItem;
 }

--- a/server/test/torrent-item.service.test.ts
+++ b/server/test/torrent-item.service.test.ts
@@ -103,6 +103,9 @@ function createDbTorrentItem(
     controlStatus: 'idle',
     tracker: 'kinozal',
     errorMessage: null,
+    notifyOnTitleChange: false,
+    notifyOnMagnetChange: false,
+    notifyOnDownloadComplete: true,
     ...override,
   } satisfies DbTorrentItem;
 }

--- a/server/test/transmission-adapter.test.ts
+++ b/server/test/transmission-adapter.test.ts
@@ -21,6 +21,9 @@ const baseItem: DbTorrentItem = {
   controlStatus: 'idle',
   tracker: 'kinozal',
   errorMessage: null,
+  notifyOnTitleChange: false,
+  notifyOnMagnetChange: false,
+  notifyOnDownloadComplete: true,
 };
 
 const baseSettings: DbUserSettings = {

--- a/server/test/transmission-management-adapter.test.ts
+++ b/server/test/transmission-management-adapter.test.ts
@@ -179,6 +179,9 @@ function createDatabaseTorrent(): DbTorrentItem {
     transmissionId: 'hash',
     controlStatus: 'downloading',
     errorMessage: null,
+    notifyOnTitleChange: false,
+    notifyOnMagnetChange: false,
+    notifyOnDownloadComplete: true,
     createdAt: 1,
     updatedAt: 1,
   };

--- a/server/test/transmission.repo.test.ts
+++ b/server/test/transmission.repo.test.ts
@@ -65,6 +65,9 @@ function makeRow(override: Partial<DbTorrentItem> = {}): DbTorrentItem {
     controlStatus: 'idle',
     tracker: 'kinozal',
     errorMessage: null,
+    notifyOnTitleChange: false,
+    notifyOnMagnetChange: false,
+    notifyOnDownloadComplete: true,
     ...override,
   } satisfies DbTorrentItem;
 }

--- a/server/test/update-worker-error-message.test.ts
+++ b/server/test/update-worker-error-message.test.ts
@@ -159,6 +159,9 @@ const baseItem: DbTorrentItem = {
   controlStatus: 'idle',
   tracker: 'kinozal',
   errorMessage: null,
+  notifyOnTitleChange: false,
+  notifyOnMagnetChange: false,
+  notifyOnDownloadComplete: true,
 };
 
 const settings: DbUserSettings = {

--- a/server/test/update-worker.test.ts
+++ b/server/test/update-worker.test.ts
@@ -8,6 +8,16 @@ import type {
   TorrentItemDto,
 } from '@server/features/torrent-item/torrent-item.types';
 
+const { sendMessageMock } = vi.hoisted(() => ({
+  sendMessageMock: vi.fn<(message: string) => Promise<void>>(),
+}));
+
+vi.mock('@server/external/adapters/telegram', () => ({
+  TelegramAdapter: class {
+    public sendMessage = sendMessageMock;
+  },
+}));
+
 // Mock logger to keep tests quiet and observable
 vi.mock('@server/lib/logger', () => ({
   default: {
@@ -275,6 +285,7 @@ class EventJournalMock implements EventJournalPort {
 describe('UpdateWorker.process', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    sendMessageMock.mockResolvedValue(undefined);
     lastTI = null;
     nextFetchError = null;
     fetchDataDelayMs = 0;
@@ -324,6 +335,35 @@ describe('UpdateWorker.process', () => {
     expect(lastTI?.markAsDownloadRequestedMock).toHaveBeenCalledTimes(1);
     expect(repo.findAllIdle).toHaveBeenCalled();
     expect(repo.findSettings).toHaveBeenCalled();
+  });
+
+  it('includes show and raw titles in title change notification', async () => {
+    const { UpdateWorker } = await import('@server/workers/update-worker');
+    const repo = new RepoMock();
+    repo.findSettings.mockResolvedValue({
+      ...settings,
+      telegramId: 123456,
+      botToken: 'bot-token',
+    });
+    const worker = new UpdateWorker({ repo: repo as unknown as never });
+
+    nextTrackerData = {
+      torrentId: 't-1',
+      rawTitle: 'Some Show S01E02 1080p',
+      showTitle: 'Some Show',
+      epAndSeason: { season: 1, startEp: 2, endEp: 2, totalEp: 12 },
+      magnet: 'MAG',
+    } satisfies TorrentDataResult;
+    nextDatabaseData = {
+      ...baseItem,
+      notifyOnTitleChange: true,
+    } satisfies DbTorrentItem;
+
+    await worker.process();
+
+    expect(sendMessageMock).toHaveBeenCalledWith(
+      'New release for "Some Show": Some Show S01E02 1080p',
+    );
   });
 
   it('does not update when tracker and DB titles match', async () => {

--- a/server/test/update-worker.test.ts
+++ b/server/test/update-worker.test.ts
@@ -89,6 +89,9 @@ const baseItem: DbTorrentItem = {
   controlStatus: 'idle',
   tracker: 'kinozal',
   errorMessage: null,
+  notifyOnTitleChange: false,
+  notifyOnMagnetChange: false,
+  notifyOnDownloadComplete: true,
 };
 
 const settings: DbUserSettings = {
@@ -198,6 +201,9 @@ vi.mock('@server/features/torrent-item/torrent-item.service', () => {
         createdAt: dbItem?.createdAt ?? Date.now(),
         updatedAt: dbItem?.updatedAt ?? Date.now(),
         errorMessage: dbItem?.errorMessage ?? null,
+        notifyOnTitleChange: dbItem?.notifyOnTitleChange ?? false,
+        notifyOnMagnetChange: dbItem?.notifyOnMagnetChange ?? false,
+        notifyOnDownloadComplete: dbItem?.notifyOnDownloadComplete ?? true,
       });
     }
     async addOrUpdate() {

--- a/server/test/workers.repo.test.ts
+++ b/server/test/workers.repo.test.ts
@@ -96,6 +96,9 @@ function makeTorrent(override: Partial<DbTorrentItem> = {}): DbTorrentItem {
     controlStatus: 'idle',
     tracker: 'kinozal',
     errorMessage: null,
+    notifyOnTitleChange: false,
+    notifyOnMagnetChange: false,
+    notifyOnDownloadComplete: true,
     ...override,
   } satisfies DbTorrentItem;
 }


### PR DESCRIPTION
## Summary

- add per-torrent notification settings in the edit dialog
- persist notification preferences through typed Hono RPC
- send Telegram notifications for configured torrent lifecycle events
- add database migration and extend worker, service, route, and adapter tests

## Rationale

Users need granular control over Telegram notifications for individual torrents instead of receiving only global notifications.

## Changes

- add notification columns and migration for torrent items
- add save-notifications API route and service mapping
- add notification settings UI to the torrent edit dialog
- gate download and update worker messages by torrent preferences

## Validation

- `bun run lint`
- `bun run test`
- `bun run build`
